### PR TITLE
add gtm as gh secret

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,7 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          GTM_ID: ${{ secrets.GTM_ID }}
           # Build output to publish to the `gh-pages` branch:
           publish_dir: ./build
           # The following lines assign commit authorship to the official

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   test-deploy:
     name: Test deployment
+    with:
+      GTM_ID: ${{ secrets.GTM_ID }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # Misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -5,6 +5,8 @@
 // See: https://docusaurus.io/docs/api/docusaurus-config
 // comment line
 
+require('dotenv').config()
+
 import {themes as prismThemes} from 'prism-react-renderer';
 
 /** @type {import('@docusaurus/types').Config} */
@@ -12,6 +14,9 @@ const config = {
   title: 'Edward Angert',
   tagline: 'Documentation Team Lead / Technical Writer',
   favicon: 'img/favicon.ico',
+  customFields: {
+    GTM_ID: process.env.GTM_ID,
+  },
 
   // Set the production url of your site here
   url: 'https://edwardangert.com',
@@ -56,6 +61,10 @@ const config = {
         }, */
         theme: {
           customCss: './src/css/custom.css',
+        },
+        gtag: {
+          trackingID: process.env.GTM_ID,
+          anonymizeIP: true,
         },
       }),
     ],

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@docusaurus/preset-classic": "3.0.0",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^1.2.1",
+    "dotenv": "^16.3.1",
     "prism-react-renderer": "^2.1.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3684,6 +3684,11 @@ dot-prop@^6.0.1:
   dependencies:
     is-obj "^2.0.0"
 
+dotenv@^16.3.1:
+  version "16.3.1"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.3.1.tgz#369034de7d7e5b120972693352a3bf112172cc3e"
+  integrity sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==
+
 duplexer@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"


### PR DESCRIPTION
Add G4 analytics via plugin and GH secret

ID isn't necessarily a "secret" but treating it as a variable keeps it out of the code in case anyone forks the repo for some reason and then doesn't change the ID