### PR TITLE
blog: The Riptide of AI Hype

### DIFF
--- a/src/content/docs/blog/riptide-of-ai-hype.mdx
+++ b/src/content/docs/blog/riptide-of-ai-hype.mdx
@@ -1,0 +1,180 @@
+---
+slug: blog/riptide-of-ai-hype
+title: "The Riptide of AI Hype"
+date: 2026-07-15
+excerpt:
+      "The AI hype bubble is going to pop. There, I said it. There's more to it, though: unverifiable promises, AI-washing, moving goalposts, and why I see the hype as a riptide."
+---
+
+In April, Allbirds sold its shoe business for $39 million and rebranded the remaining public shell as NewBird AI, a GPU-as-a-service company.
+The stock jumped roughly 600% on the announcement.
+This was a business that lost $77 million the year before and closed every full-price store in the US.
+
+To be precise, because I can hear the "well, actually"s coming: the shoes still exist, under new ownership.
+It's the public company, the ticker, the thing investors buy, that became an AI company overnight.
+
+A few weeks later, Everlane, another once-beloved direct-to-consumer brand, sold to Shein for $100 million in a deal structured mainly to absolve $90 million in debt.
+Common shareholders got nothing.
+
+Two brands from the same era, and the media framing is existential-feeling: sell out, or pivot to AI.
+
+That's a riptide.
+A current under the surface, pulling everything in one direction whether it wants to go there or not.
+
+## This Isn't About Deception
+
+I want this up top, and I want to state it carefully because the shorthand of this post already exists a thousand times over.
+
+The problem isn't that AI companies are lying.
+
+It's that the industry subsists on grandiose promises delicately hinged on GDP-level funding and hardware requirements, with the intention to spend until we discover what the capabilities actually are.
+
+My skepticism isn't about AI itself.
+It's about the desperation to make _everything_ about AI.
+
+The bubble is that at some point, that has to shake itself out, and nobody knows what we'll be left with, or who will be left behind.
+
+My claim is not that "AI doesn't work."
+I use these tools every day, [at home and at work](../ai-docs-assist/), and they keep surprising me.
+Sometimes in good ways.
+
+And it's not "the promises are false."
+
+It's that the promises are unverifiable right now, because the underlying capability is still being discovered, at enormous cost, in public, by all of us.
+
+I'm not the first to identify this distinction.
+Read Andreu Belsunces Gonçalves for what they call [deep hype](https://arxiv.org/abs/2508.19749): a long-term, overpromissory dynamic that makes not-yet-existing technologies feel both desirable and urgent, sustained by belief and speculation rather than deliberate falsehood.
+
+A person who exaggerates their resume knows what they can't do.
+This hype is more like a person who genuinely doesn't know their own qualifications yet, interviewing for every job at once, and getting paid while they work out the details.
+
+## The Money Isn't Subtle About It
+
+AI captured 81% of the record $300 billion in global VC funding in the first quarter of this year.
+A year earlier it was 55%.
+In 2022 it was around 30%.
+Four companies, OpenAI, Anthropic, xAI, and Waymo, absorbed roughly 65% of all global venture dollars in a single quarter.
+
+But concentration of capital isn't the same claim as progress being set back, and the two get blurred if you're not careful.
+Non-AI startups still pulled in about $58 billion that quarter, a figure that would have led every quarter before 2018.
+
+The sharper version of the argument isn't "there's no money outside AI."
+It's that the shape of what still gets funded outside AI has narrowed to things AI can't touch: defense, fintech, digital health, advanced manufacturing.
+Categories with proprietary data, licenses, or physical moats.
+Horizontal SaaS funding dropped roughly 35% over the previous year, not because it stopped being useful, but because AI threatens to commoditize what it used to charge for.
+
+Meanwhile, [PR agencies estimate](https://finance.yahoo.com/news/companies-increasingly-ai-washing-212940553.html) about half the AI pitches they're asked to place are relabeled automation or unrelated products chasing an AI premium.
+There's a name for this now, "AI-washing", and it's been compared directly to dot-com era name-inflation.
+Add `.com` to your name in 1999, add `AI` to your deck in 2026.
+
+## The Deeper Hole Isn't Dollars, It's Defaults
+
+This is the part that kicked off this whole post.
+
+If you're a technologist with a genuinely good non-AI idea, the rational move now is to fold AI into it, or watch it get less attention, less capital, and less institutional patience than an AI-flavored version of the same effort would get.
+
+[Founder-facing advice says it outright](https://insights4vc.substack.com/p/ai-captured-80-of-global-venture): position your startup inside the AI funding currents, or watch from the sidelines.
+
+Y Combinator's newest batches run more than 60% AI, at the earliest, most idea-stage layer of the pipeline, before product-market fit, before revenue.
+The exact moment a new non-AI idea would otherwise get its first shot.
+
+That's not a claim about total funding levels.
+It's a claim about what gets built in the first place.
+
+And it's not just startups.
+The same pattern shows up in academic science, with better sourcing than anything I could add: [peer-reviewed work](https://www.nature.com/articles/s44271-026-00428-5) arguing that AI's proliferation risks a scientific monoculture, where funding priorities, journal norms, and career incentives increasingly reward AI-centered work, so pursuing non-AI research carries career risk.
+Same mechanism, different room.
+Grant committees instead of term sheets.
+
+Here's my own extrapolation, and I'll flag it as mine because I haven't found anyone making this specific case yet: I suspect starving the adjacent fields eventually slows AI's own progress.
+
+The clearest documented version is mathematics, where there's [a real argument](https://www.ox.ac.uk/news/2026-02-11-expert-comment-how-and-why-mathematics-will-both-underpin-and-lead-next-generation) that mathematical structure is the scaffolding intelligent systems need, not an accessory bolted on after the fact.
+Without it, AI stays fast but brittle.
+I'd bet the same is true of cryptography and philosophy, but that's my hunch, not a citation.
+
+## What the Gloss Covers, Part One: Nobody Fully Understands the Mechanism
+
+Start with the people who'd have the most reason to overstate their own understanding, and listen to what they actually admit.
+
+Anthropic's CEO has called the current opacity of these systems [essentially unprecedented in the history of technology](https://www.darioamodei.com/post/the-urgency-of-interpretability), and said plainly that nobody knows, at a precise level, why the model made the choice it made.
+OpenAI's CEO, asked directly how his own models work, [said](https://futurism.com/sam-altman-admits-openai-understand-ai): we certainly have not solved interpretability.
+
+Forty researchers across OpenAI, Google DeepMind, Anthropic, and Meta, a list that includes Ilya Sutskever and Geoffrey Hinton, warned that even the partial visibility labs currently have [isn't guaranteed to survive as models get more capable](https://arxiv.org/abs/2507.11473).
+
+That's not a caveat buried in a footnote.
+That's the industry's own position paper.
+
+## The Gloss, Part Two: Nobody Knows the Ceiling, and the Surprises Run the Other Way
+
+The reason I keep insisting this isn't a purely "AI bubble" post.
+
+The historical pattern isn't labs overselling and reality falling short.
+It's the opposite, more often than you'd expect.
+Some of this stuff's actually good.
+
+In 2021, professional superforecasters [predicted](https://www.lesswrong.com/posts/CJw2tNHaEimx6nwNy/ai-forecasting-one-year-in) the best model would hit 12.7% accuracy on a hard math benchmark by mid-2022, and considered anything above 20% unlikely.
+The actual result was 50.3%.
+[Researchers keep documenting](https://arxiv.org/abs/2109.13916) capabilities that emerged without anyone training for them, and [the main way anyone learns a model's outer limits](https://arxiv.org/abs/2307.03718) has been iterative public deployment, not internal lab knowledge.
+
+Large models keep turning out to have [capabilities their own designers didn't know were there](https://www.planned-obsolescence.org/language-models-surprised-us/) until the public went looking after release.
+
+So when someone says AI might genuinely help cure a disease, that's not automatically hype.
+It's consistent with the documented pattern of real capability being underestimated.
+But genuine-but-unproven potential is a different category of claim from "does everything, everywhere, fixes everything," and the current discourse treats them as interchangeable.
+Real capability keeps outrunning anyone's ability to forecast it, in both directions, and almost nobody is being precise about which direction they mean.
+
+## AGI: The Amorphous Definition
+
+AGI was the dream.
+
+A single term everyone could rally behind or against.
+Then nobody could agree on what it meant.
+
+Then the definition changed.
+Now I barely hear anything about it.
+
+[Peer-reviewed correspondence in Nature](https://www.nature.com/articles/d41586-026-00495-y) this February found the definition has been rewritten three times in a decade, and each rewrite landed exactly when existing systems were about to fail the previous version of the test.
+[The original 2007 bar](https://arxiv.org/abs/0712.3329), reliable generalization with no task-specific tuning, still isn't met by anything on the market.
+
+[OpenAI's own charter](https://openai.com/charter/) caps investor returns once AGI is formally declared, which means the company deciding whether AGI has arrived has a direct financial stake in how that word gets defined.
+Even Sam Altman, the person most publicly associated with chasing it, has called AGI "a very sloppy term" and "not a super useful term," in the same period he kept using it in predictions.
+[Serious people have claimed AGI was achieved on at least three separate dates in the past year](https://helentoner.substack.com/p/the-term-agi-is-almost-useless-at), while others place it a decade or more out.
+
+The vocabulary is shifting toward "superintelligence" now.
+
+Not because the ambition changed, but because the old word got worn out by its own definitional churn.
+Goalposts?
+Where we're going, we don't need goalposts.
+
+## Swim Parallel to the Shore
+
+The advice for an actual riptide isn't to fight the current, and it isn't to let it take you.
+It's to swim parallel to the shore until you're out of the pull, then make your way back in.
+
+The honest position isn't "AI is a bubble" or "AI will fix everything."
+It's that AI is genuinely, verifiably capable of things nobody, including the people building it, fully understands or has finished discovering.
+And at the exact same time, an enormous amount of capital, attention, and career incentive is being spent selling you something else: a universal fix, a funding strategy, a word to append to a press release.
+
+Sifting the real capability from the gloss is the actual work right now.
+Almost nobody is doing that work in public, because the incentives on all sides reward saying the loud version instead.
+
+This is my small attempt at doing it in public.
+
+I built the research for this post in conversations with Claude Sonnet, and had Claude Fable draft it in its attempt at my voice.
+Then I edited it the way I'd edit any subject matter expert's draft: checked the claims, demanded citations, cut what didn't hold up, and rewrote the ending twice.
+
+I used the thing I'm skeptical about to write the skepticism, and it saved me hours.
+Is it perfect?
+It gets the point across.
+I don't have a cleaner way to hold both halves of this essay at once, and I'm not sure one exists yet.
+Use your favorite AI tool to summarize it for you.
+
+[Last time](../chasing-meta/), I wrote about chasing the meta while keeping your "why" close.
+This is the same idea at economy scale.
+Experiment with the tools.
+Take the capability seriously, it keeps being more real than the forecasts.
+But when the current tries to pull your work, your funding, your field, or your public company's ticker symbol toward AI whether it belongs there or not, that's not the wave to ride.
+
+That's the one to swim parallel to, keep your head up, and wait out.
+
+And hold on to your shoes.


### PR DESCRIPTION
## What

New blog post: **The Riptide of AI Hype** (`src/content/docs/blog/riptide-of-ai-hype.mdx`).

The post argues that the problem with AI hype isn't deception, it's unverifiable promises funded like they're already true: AI-washing, capital concentration, the steering of what gets built in the first place, the interpretability gap the labs themselves admit, capability that keeps beating the forecasts, and the AGI definition that kept moving.

## Why Claude is opening this PR

Edward asked me to have the honors, because it's extra fitting for this post. The essay discloses its own workflow: researched in conversations with Claude Sonnet, drafted by Claude Fable in its attempt at his voice, then edited by Edward the way he'd edit any subject matter expert's draft (claims checked, citations demanded, endings rewritten twice). Having the tool the post is skeptical about open the pull request for it is the joke, and also the point: sift the real capability from the gloss, then use what's real.

## Notes

- Every citation resolved and verified against primary or near-primary sources (Nature correspondence, arXiv position papers, the OpenAI charter, Steinhardt's forecasting contest, the deep-hype paper the framing nods to)
- Site builds clean; post is picked up automatically by starlight-blog

🤖 Generated with [Claude Code](https://claude.com/claude-code)