### PR TITLE
Add click-to-zoom lightbox for content images

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -20,7 +20,7 @@ export default defineConfig({
 			title: 'Edward Angert',
 			favicon: '/favicon.ico',
 			tagline: 'Technical writer, team leader, relationship-builder',
-			customCss: ['./src/styles/tables.css', './src/styles/frosted-glass.css'],
+			customCss: ['./src/styles/tables.css', './src/styles/frosted-glass.css', './src/styles/images.css'],
 			disable404Route: true,
 			components: {
 				PageTitle: './src/components/PageTitle.astro',

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -2,11 +2,14 @@
 import type { Props } from '@astrojs/starlight/props';
 import StarlightHead from '@astrojs/starlight/components/Head.astro';
 import PostHog from './posthog.astro';
+import ImageLightbox from './ImageLightbox.astro';
 ---
 
 <StarlightHead {...Astro.props}>
   <slot />
 </StarlightHead>
+
+<ImageLightbox />
 
 <!-- clarity (disabled in favor of PostHog) -->
 <!--

--- a/src/components/ImageLightbox.astro
+++ b/src/components/ImageLightbox.astro
@@ -1,0 +1,58 @@
+---
+// Click-to-zoom lightbox for content images.
+// Hand-rolled because starlight-image-zoom doesn't yet support Astro 7's
+// default "Sätteri" markdown processor: https://github.com/HiDeoo/starlight-image-zoom/issues/63
+---
+
+<script>
+  declare global {
+    interface Window {
+      __imageLightboxInit?: boolean;
+    }
+  }
+
+  function initImageLightbox() {
+    if (window.__imageLightboxInit) return;
+    window.__imageLightboxInit = true;
+
+    let overlay: HTMLDivElement | null = null;
+
+    function closeLightbox() {
+      overlay?.remove();
+      overlay = null;
+      document.removeEventListener('keydown', onKeydown);
+    }
+
+    function onKeydown(e: KeyboardEvent) {
+      if (e.key === 'Escape') closeLightbox();
+    }
+
+    function openLightbox(src: string, alt: string) {
+      overlay = document.createElement('div');
+      overlay.className = 'image-lightbox-overlay';
+      overlay.setAttribute('role', 'dialog');
+      overlay.setAttribute('aria-modal', 'true');
+
+      const img = document.createElement('img');
+      img.src = src;
+      img.alt = alt || '';
+      img.className = 'image-lightbox-img';
+
+      overlay.appendChild(img);
+      overlay.addEventListener('click', closeLightbox);
+      document.body.appendChild(overlay);
+      document.addEventListener('keydown', onKeydown);
+    }
+
+    document.addEventListener('click', (e) => {
+      const target = e.target;
+      if (!(target instanceof HTMLImageElement)) return;
+      if (!target.closest('.sl-markdown-content')) return;
+      if (target.closest('a')) return; // already a link; don't hijack it
+      openLightbox(target.currentSrc || target.src, target.alt);
+    });
+  }
+
+  initImageLightbox();
+  document.addEventListener('astro:page-load', initImageLightbox);
+</script>

--- a/src/styles/images.css
+++ b/src/styles/images.css
@@ -1,0 +1,45 @@
+/* Center content images by default, capped at 800px since the lightbox
+   below covers full-resolution viewing.
+   Element-selector specificity (0,0,1) makes this easy to override with a
+   class or inline style on a specific image. */
+img {
+  display: block;
+  margin-inline: auto;
+  max-width: min(800px, 100%);
+}
+
+/* Click-to-zoom lightbox for content images (see ImageLightbox.astro).
+   Hand-rolled because starlight-image-zoom doesn't yet support Astro 7's
+   default "Sätteri" markdown processor. */
+.sl-markdown-content img {
+  cursor: zoom-in;
+}
+
+.image-lightbox-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.85);
+  cursor: zoom-out;
+  animation: image-lightbox-fade-in 0.15s ease-out;
+}
+
+.image-lightbox-img {
+  max-width: 90vw;
+  max-height: 90vh;
+  margin: 0;
+  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.5);
+  border-radius: 4px;
+}
+
+@keyframes image-lightbox-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Summary
- Centers content images by default and caps their width at 800px, since the lightbox now covers full-resolution viewing
- Hand-rolled click-to-zoom lightbox (`ImageLightbox.astro`): vanilla JS, no dependencies, opens a full-viewport overlay on click, closes on click or Escape
- `starlight-image-zoom` was evaluated first but doesn't yet support Astro 7's default Satteri markdown processor ([tracking issue](https://github.com/HiDeoo/starlight-image-zoom/issues/63))

## Test plan
- [x] `pnpm build` passes
- [x] Verified the lightbox script and CSS are present in the compiled `dist/` output
- [x] Manual check in a browser: click an image in a doc, confirm it opens full-resolution centered on a dark overlay, confirm Escape and click-to-dismiss both work
- [x] Confirm images already wrapped in a link (e.g. the portfolio diagram's "Link to PNG" pattern) aren't double-handled

🤖 Generated with [Claude Code](https://claude.com/claude-code)