### PR TITLE
Add markdownlint and Vale linting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,12 @@ pnpm-debug.log*
 
 # PostHog wizard skill (local agent context, not shipped)
 .claude/skills/integration-astro-static/
+
+# Vale style packages fetched by `vale sync`. DocsAssist is our own style
+# and stays tracked; Google/write-good/alex are managed upstream packages.
+/styles/Google/
+/styles/write-good/
+/styles/alex/
+
+# Vale binary fetched locally by scripts/vale.sh when not on PATH.
+/.bin/

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,149 @@
+{
+  // Brought over from Docs Assist's opinionated default
+  // (docs-agent-plugin/assets/lint/markdownlint/.markdownlint.jsonc).
+  // Every rule below was reviewed and decided explicitly, not left to
+  // markdownlint's built-in defaults. `default: true` only catches rules
+  // newer than this list.
+  "default": true,
+  // MD001 - Heading levels increment by one at a time.
+  "MD001": true,
+  // MD003 - Heading style: consistent with whatever the first heading uses
+  // (not forced to ATX or Setext specifically).
+  "MD003": {
+    "style": "consistent"
+  },
+  // MD004 - Unordered lists use "-".
+  "MD004": {
+    "style": "dash"
+  },
+  // MD005 - Consistent indentation for list items at the same level.
+  "MD005": true,
+  // MD007 - Unordered list indentation.
+  "MD007": true,
+  // MD009 - No trailing spaces.
+  "MD009": true,
+  // MD010 - Hard tabs: not enforced.
+  "MD010": false,
+  // MD011 - No reversed link syntax, for example (text)[url].
+  "MD011": true,
+  // MD012 - No multiple consecutive blank lines.
+  "MD012": true,
+  // MD013 - Line length: not enforced. One-sentence-per-line means lines
+  // are intentionally long; wrapping by character count fights that.
+  "MD013": false,
+  // MD014 - No dollar signs before shell commands that show no output.
+  "MD014": true,
+  // MD018-MD021 - Hash spacing on ATX-style headings, opening and closed.
+  "MD018": true,
+  "MD019": true,
+  "MD020": true,
+  "MD021": true,
+  // MD022 - Headings surrounded by blank lines.
+  "MD022": true,
+  // MD023 - Headings must start at the beginning of the line.
+  "MD023": true,
+  // MD024 - Allow the same heading text under different parents (common in
+  // structured docs); still flags duplicates within the same parent.
+  "MD024": {
+    "siblings_only": true
+  },
+  // MD025 - One H1 per file. Ignore the frontmatter "title" field so docs can
+  // carry both a frontmatter title and a matching body H1.
+  "MD025": {
+    "front_matter_title": ""
+  },
+  // MD026 - Trailing punctuation in headings. Allow "?" for FAQ-style titles;
+  // flag everything else.
+  "MD026": {
+    "punctuation": ".,;:!。，；：！"
+  },
+  // MD027 - No multiple spaces after the blockquote symbol.
+  "MD027": true,
+  // MD028 - No blank line inside a blockquote.
+  "MD028": true,
+  // MD029 - Ordered list numbering: either repeated "1." or true sequential
+  // numbering, as long as a single list is internally consistent.
+  "MD029": {
+    "style": "one_or_ordered"
+  },
+  // MD030 - Spaces after list markers.
+  "MD030": true,
+  // MD031 - Fenced code blocks surrounded by blank lines.
+  "MD031": true,
+  // MD032 - Lists surrounded by blank lines.
+  "MD032": true,
+  // MD033 - Allow the HTML disclosure elements, this site's Starlight/MDX
+  // components, and the handful of raw HTML tags used deliberately (kbd for
+  // key names, p/em for a styled image caption). All other inline HTML is
+  // still flagged.
+  "MD033": {
+    "allowed_elements": [
+      "details",
+      "summary",
+      "kbd",
+      "p",
+      "em",
+      "CardGrid",
+      "Code",
+      "ColumnList",
+      "Image",
+      "LinkCard",
+      "Steps",
+      "TabItem",
+      "Tabs"
+    ]
+  },
+  // MD034 - No bare URLs; wrap them in angle brackets or link syntax.
+  "MD034": true,
+  // MD035 - Consistent horizontal rule style.
+  "MD035": true,
+  // MD036 - No emphasis used in place of a heading.
+  "MD036": true,
+  // MD037-MD039 - No stray spaces inside emphasis, code span, or link text.
+  "MD037": true,
+  "MD038": true,
+  "MD039": true,
+  // MD040 - Fenced code blocks must declare a language.
+  "MD040": true,
+  // MD041 - First line does not have to be a top-level heading (frontmatter
+  // usually comes first).
+  "MD041": false,
+  // MD042 - No empty links.
+  "MD042": true,
+  // MD043 - Required heading structure: not enforced. Content type dictates
+  // structure; a single fixed skeleton does not fit every doc.
+  "MD043": false,
+  // MD044 - Proper-name capitalization: not enforced.
+  "MD044": false,
+  // MD045 - Images must have alt text.
+  "MD045": true,
+  // MD046 - Consistent code block style (fenced vs. indented).
+  "MD046": true,
+  // MD047 - Files end with a single newline.
+  "MD047": true,
+  // MD048 - Code fence style (``` vs. ~~~): not enforced.
+  "MD048": false,
+  // MD049 - Emphasis style (* vs. _): not enforced.
+  "MD049": false,
+  // MD050 - Strong style (** vs. __): not enforced.
+  "MD050": false,
+  // MD051 - Link fragments must resolve to a real heading or anchor.
+  "MD051": true,
+  // MD052 - Reference links/images must use a defined label: not enforced.
+  "MD052": false,
+  // MD053 - Unused link/image reference definitions: not enforced.
+  "MD053": false,
+  // MD054 - Link and image style (inline vs. reference vs. autolink): not
+  // enforced.
+  "MD054": false,
+  // MD055 - Consistent table pipe style.
+  "MD055": true,
+  // MD056 - Consistent table column count per row.
+  "MD056": true,
+  // MD058 - Tables surrounded by blank lines.
+  "MD058": true,
+  // MD059 - Descriptive link text; flags "click here" and similar.
+  "MD059": true,
+  // MD060 - Consistent table column alignment style: not enforced.
+  "MD060": false
+}

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,58 @@
+# Vale configuration for edwardangert.github.io.
+#
+# Brought over from Docs Assist (docs-agent-plugin/assets/lint/vale/.vale.ini).
+# General prose quality is a managed problem, not something this site keeps
+# its own copy of: Google, write-good, and alex are Vale's own style
+# packages, actively maintained upstream, covering weasel words, passive
+# voice, wordiness, clichés, heading and punctuation conventions, and
+# inclusive language. `vale sync` downloads them.
+#
+# The DocsAssist style is deliberately small: only what those packages do
+# not cover; AI voice (hedging, marketing language, false-contrast framing,
+# throat-clearing openers) and this site's own conventions (no em dashes,
+# descriptive link text, imperative headings).
+#
+# Spelling is left to cspell to avoid duplicate noise.
+
+StylesPath = styles
+MinAlertLevel = suggestion
+Packages = Google, write-good, alex
+
+# Parse .mdx as plain Markdown. Vale's native MDX support requires an
+# external mdx2vast converter that isn't installed here, and Starlight's
+# JSX components (LinkCard, CardGrid, etc.) read fine as inline HTML to
+# Vale's Markdown parser for prose-linting purposes.
+[formats]
+mdx = md
+
+[src/content/docs/**/*.{md,mdx}]
+BasedOnStyles = Vale, Google, write-good, alex, DocsAssist
+
+# cspell owns spelling.
+Vale.Spelling = NO
+
+# This site's headings are title case (see existing blog and portfolio
+# posts), not sentence case, so Google's sentence-case assumption would
+# flag nearly every heading in the site.
+Google.Headings = NO
+
+# Google.EmDash is a formatting check (spacing, character), not a ban.
+# DocsAssist.EmDash already bans em dashes outright, so disable Google's
+# softer rule to avoid a duplicate, confusing finding on the same em dash.
+Google.EmDash = NO
+
+# Google.Quotes enforces American style (commas and periods always inside
+# quotation marks). Disabled: this site quotes exact terms, commands, and
+# search queries ("so how do i know if pihole works") where the punctuation
+# is genuinely outside the quoted string, not part of it.
+Google.Quotes = NO
+
+# Google.Units expects a nonbreaking space between a number and a unit
+# (4 km, not 4km). It also fires on section references that only look like
+# a number-plus-letter pair, which is not a unit at all. Disabled rather
+# than fought one false positive at a time.
+Google.Units = NO
+
+# alex.Condescending flags words like "obvious," "easy," and "clearly" by
+# existence alone. Disabled; alex's other inclusive-language rules stay on.
+alex.Condescending = NO

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "start": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "lint:md": "markdownlint-cli2 \"src/content/docs/**/*.mdx\"",
+    "lint:vale": "scripts/vale.sh .",
+    "lint": "pnpm lint:md && pnpm lint:vale"
   },
   "dependencies": {
     "@astrojs/starlight": "^0.41.3",
@@ -17,5 +20,8 @@
     "sharp": "^0.35.3",
     "starlight-blog": "^0.27.0",
     "starlight-fullview-mode": "^0.2.6"
+  },
+  "devDependencies": {
+    "markdownlint-cli2": "^0.23.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,10 @@ importers:
       starlight-fullview-mode:
         specifier: ^0.2.6
         version: 0.2.6(@astrojs/starlight@0.41.3(@astrojs/markdown-remark@7.2.1)(astro@7.1.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.1)))
+    devDependencies:
+      markdownlint-cli2:
+        specifier: ^0.23.1
+        version: 0.23.1
 
 packages:
 
@@ -593,6 +597,18 @@ packages:
   '@nodable/entities@2.2.0':
     resolution: {integrity: sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==}
 
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
 
@@ -775,6 +791,10 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@sindresorhus/merge-streams@4.0.0':
+    resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
+    engines: {node: '>=18'}
+
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
@@ -792,6 +812,9 @@ packages:
 
   '@types/js-yaml@4.0.9':
     resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
+
+  '@types/katex@0.16.8':
+    resolution: {integrity: sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==}
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
@@ -836,6 +859,10 @@ packages:
   am-i-vibing@0.4.0:
     resolution: {integrity: sha512-MxT4XZL7pzLHpuvhDKdMaQHMGGkJDLluKBLsbstn+8wv9sWcFT6h+0ve9qkml95amVTZtZV83gQe2hY+ojgHLg==}
     hasBin: true
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
 
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
@@ -892,6 +919,10 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
@@ -928,6 +959,10 @@ packages:
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
 
   common-ancestor-path@2.0.0:
     resolution: {integrity: sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==}
@@ -1086,6 +1121,10 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
   fast-string-truncated-width@3.0.3:
     resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
 
@@ -1102,6 +1141,9 @@ packages:
     resolution: {integrity: sha512-SLhnTEqE5QpJHq/6zl9bsmImEP2adv+y6Wy+cJa7nVTRzQh1OZfCe9k29M5xN74LWnu0xa1zrUrq3KnOKl92Fg==}
     hasBin: true
 
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -1110,6 +1152,10 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
 
   flattie@1.1.1:
     resolution: {integrity: sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==}
@@ -1127,12 +1173,24 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
   get-tsconfig@5.0.0-beta.4:
     resolution: {integrity: sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ==}
     engines: {node: '>=20.20.0'}
 
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
+  globby@16.2.1:
+    resolution: {integrity: sha512-JmsqJalahxxgW8V2ecSQ2G7UjPlI9cpKdrkG9KoNiXhd/YslXOTEB0cViENWUznuovIuNT+FkMbraDGjr4FCUg==}
+    engines: {node: '>=20'}
 
   h3@1.15.11:
     resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
@@ -1217,6 +1275,10 @@ packages:
       typescript:
         optional: true
 
+  ignore@7.0.6:
+    resolution: {integrity: sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==}
+    engines: {node: '>= 4'}
+
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
@@ -1237,8 +1299,24 @@ packages:
     engines: {node: '>=20'}
     hasBin: true
 
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  is-path-inside@4.0.0:
+    resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
+    engines: {node: '>=12'}
 
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
@@ -1251,8 +1329,20 @@ packages:
     resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
+  js-yaml@5.2.1:
+    resolution: {integrity: sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==}
+    hasBin: true
+
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
+  jsonpointer@5.0.1:
+    resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
+    engines: {node: '>=0.10.0'}
+
+  katex@0.16.47:
+    resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
+    hasBin: true
 
   klona@2.0.6:
     resolution: {integrity: sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==}
@@ -1332,6 +1422,9 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  linkify-it@5.0.2:
+    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
+
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
@@ -1349,8 +1442,26 @@ packages:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
     engines: {node: '>=16'}
 
+  markdown-it@14.3.0:
+    resolution: {integrity: sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==}
+    hasBin: true
+
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  markdownlint-cli2-formatter-default@0.0.6:
+    resolution: {integrity: sha512-VVDGKsq9sgzu378swJ0fcHfSicUnMxnL8gnLm/Q4J/xsNJ4e5bA6lvAz7PCzIl0/No0lHyaWdqVD2jotxOSFMQ==}
+    peerDependencies:
+      markdownlint-cli2: '>=0.0.4'
+
+  markdownlint-cli2@0.23.1:
+    resolution: {integrity: sha512-20JPI5W+HpV1OA+pUM712wgvL4GzYNUvbmhLU8KlEYJ1kCDx4soZ4/Xqd+WkLrPTOKMAn8SfO3zYFrK8GLlwQg==}
+    engines: {node: '>=22'}
+    hasBin: true
+
+  markdownlint@0.41.1:
+    resolution: {integrity: sha512-qHKeU2E1bdyNAT077go2FVTNXvYcktN5IHtF6XyeD1l0PClxzSp2tUApAV14ORI8DGX4H9bNKZEzelZp4qn8IA==}
+    engines: {node: '>=22'}
 
   mdast-util-definitions@6.0.0:
     resolution: {integrity: sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==}
@@ -1412,6 +1523,13 @@ packages:
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
+  mdurl@2.1.0:
+    resolution: {integrity: sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
 
@@ -1438,6 +1556,9 @@ packages:
 
   micromark-extension-gfm@3.0.0:
     resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-extension-math@3.1.0:
+    resolution: {integrity: sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==}
 
   micromark-extension-mdx-expression@3.0.1:
     resolution: {integrity: sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==}
@@ -1519,6 +1640,10 @@ packages:
 
   micromark@4.0.2:
     resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
 
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
@@ -1639,6 +1764,13 @@ packages:
   property-information@7.2.0:
     resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
 
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
 
@@ -1727,10 +1859,17 @@ packages:
   retext@9.0.0:
     resolution: {integrity: sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==}
 
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
   rolldown@1.1.5:
     resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
   satteri@0.9.5:
     resolution: {integrity: sha512-ZuWVl+vnM64y+/TtX8Kosv2c00W+hLQiiwnEL6H0UKVVrxFqMw4D2CJHHQaouVd89OAhtBBfjWLqhKi3TVUV4w==}
@@ -1765,6 +1904,10 @@ packages:
     engines: {node: '>=20.19.5', npm: '>=10.8.2'}
     hasBin: true
 
+  slash@5.1.0:
+    resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
+    engines: {node: '>=14.16'}
+
   smol-toml@1.7.0:
     resolution: {integrity: sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==}
     engines: {node: '>= 18'}
@@ -1795,8 +1938,16 @@ packages:
   stream-replace-string@2.0.0:
     resolution: {integrity: sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==}
 
+  string-width@8.2.1:
+    resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
+    engines: {node: '>=20'}
+
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
 
   strnum@2.4.1:
     resolution: {integrity: sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==}
@@ -1827,6 +1978,10 @@ packages:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
@@ -1835,6 +1990,9 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
@@ -1850,6 +2008,10 @@ packages:
 
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
+  unicorn-magic@0.4.0:
+    resolution: {integrity: sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==}
+    engines: {node: '>=20'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -2578,6 +2740,18 @@ snapshots:
 
   '@nodable/entities@2.2.0': {}
 
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
+
   '@oslojs/encoding@1.1.0': {}
 
   '@oxc-project/types@0.139.0': {}
@@ -2702,6 +2876,8 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@sindresorhus/merge-streams@4.0.0': {}
+
   '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
@@ -2722,6 +2898,8 @@ snapshots:
       '@types/unist': 3.0.3
 
   '@types/js-yaml@4.0.9': {}
+
+  '@types/katex@0.16.8': {}
 
   '@types/mdast@4.0.4':
     dependencies:
@@ -2762,6 +2940,8 @@ snapshots:
   am-i-vibing@0.4.0:
     dependencies:
       process-ancestry: 0.1.0
+
+  ansi-regex@6.2.2: {}
 
   anymatch@3.1.3:
     dependencies:
@@ -2893,6 +3073,10 @@ snapshots:
 
   boolbase@1.0.0: {}
 
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
   ccount@2.0.1: {}
 
   character-entities-html4@2.1.0: {}
@@ -2916,6 +3100,8 @@ snapshots:
   comma-separated-tokens@2.0.3: {}
 
   commander@11.1.0: {}
+
+  commander@8.3.0: {}
 
   common-ancestor-path@2.0.0: {}
 
@@ -3098,6 +3284,14 @@ snapshots:
 
   extend@3.0.2: {}
 
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
   fast-string-truncated-width@3.0.3: {}
 
   fast-string-width@3.0.2:
@@ -3122,9 +3316,17 @@ snapshots:
       strnum: 2.4.1
       xml-naming: 0.3.0
 
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
+
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
 
   flattie@1.1.1: {}
 
@@ -3139,11 +3341,26 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  get-east-asian-width@1.6.0: {}
+
   get-tsconfig@5.0.0-beta.4:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
   github-slugger@2.0.0: {}
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  globby@16.2.1:
+    dependencies:
+      '@sindresorhus/merge-streams': 4.0.0
+      fast-glob: 3.3.3
+      ignore: 7.0.6
+      is-path-inside: 4.0.0
+      slash: 5.1.0
+      unicorn-magic: 0.4.0
 
   h3@1.15.11:
     dependencies:
@@ -3356,6 +3573,8 @@ snapshots:
 
   i18next@26.3.6: {}
 
+  ignore@7.0.6: {}
+
   inline-style-parser@0.2.7: {}
 
   iron-webcrypto@1.2.1: {}
@@ -3371,7 +3590,17 @@ snapshots:
 
   is-docker@4.0.0: {}
 
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
   is-hexadecimal@2.0.1: {}
+
+  is-number@7.0.0: {}
+
+  is-path-inside@4.0.0: {}
 
   is-plain-obj@4.1.0: {}
 
@@ -3381,7 +3610,17 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  js-yaml@5.2.1:
+    dependencies:
+      argparse: 2.0.1
+
   jsonc-parser@3.3.1: {}
+
+  jsonpointer@5.0.1: {}
+
+  katex@0.16.47:
+    dependencies:
+      commander: 8.3.0
 
   klona@2.0.6: {}
 
@@ -3434,6 +3673,10 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  linkify-it@5.0.2:
+    dependencies:
+      uc.micro: 2.1.0
+
   longest-streak@3.1.0: {}
 
   lru-cache@11.5.2: {}
@@ -3450,7 +3693,48 @@ snapshots:
 
   markdown-extensions@2.0.0: {}
 
+  markdown-it@14.3.0:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.2
+      mdurl: 2.1.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
   markdown-table@3.0.4: {}
+
+  markdownlint-cli2-formatter-default@0.0.6(markdownlint-cli2@0.23.1):
+    dependencies:
+      markdownlint-cli2: 0.23.1
+
+  markdownlint-cli2@0.23.1:
+    dependencies:
+      globby: 16.2.1
+      js-yaml: 5.2.1
+      jsonc-parser: 3.3.1
+      jsonpointer: 5.0.1
+      markdown-it: 14.3.0
+      markdownlint: 0.41.1
+      markdownlint-cli2-formatter-default: 0.0.6(markdownlint-cli2@0.23.1)
+      micromatch: 4.0.8
+      smol-toml: 1.7.0
+    transitivePeerDependencies:
+      - supports-color
+
+  markdownlint@0.41.1:
+    dependencies:
+      micromark: 4.0.2
+      micromark-core-commonmark: 2.0.3
+      micromark-extension-directive: 4.0.0
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-math: 3.1.0
+      micromark-util-types: 2.0.2
+      string-width: 8.2.1
+    transitivePeerDependencies:
+      - supports-color
 
   mdast-util-definitions@6.0.0:
     dependencies:
@@ -3639,6 +3923,10 @@ snapshots:
 
   mdn-data@2.27.1: {}
 
+  mdurl@2.1.0: {}
+
+  merge2@1.4.1: {}
+
   micromark-core-commonmark@2.0.3:
     dependencies:
       decode-named-character-reference: 1.3.0
@@ -3724,6 +4012,16 @@ snapshots:
       micromark-extension-gfm-tagfilter: 2.0.0
       micromark-extension-gfm-task-list-item: 2.1.0
       micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-math@3.1.0:
+    dependencies:
+      '@types/katex': 0.16.8
+      devlop: 1.1.0
+      katex: 0.16.47
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
 
   micromark-extension-mdx-expression@3.0.1:
@@ -3913,6 +4211,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
+
   mrmime@2.0.1: {}
 
   ms@2.1.3: {}
@@ -4030,6 +4333,10 @@ snapshots:
   process-ancestry@0.1.0: {}
 
   property-information@7.2.0: {}
+
+  punycode.js@2.3.1: {}
+
+  queue-microtask@1.2.3: {}
 
   radix3@1.1.2: {}
 
@@ -4200,6 +4507,8 @@ snapshots:
       retext-stringify: 4.0.0
       unified: 11.0.5
 
+  reusify@1.1.0: {}
+
   rolldown@1.1.5:
     dependencies:
       '@oxc-project/types': 0.139.0
@@ -4220,6 +4529,10 @@ snapshots:
       '@rolldown/binding-wasm32-wasi': 1.1.5
       '@rolldown/binding-win32-arm64-msvc': 1.1.5
       '@rolldown/binding-win32-x64-msvc': 1.1.5
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
 
   satteri@0.9.5:
     dependencies:
@@ -4295,6 +4608,8 @@ snapshots:
       arg: 5.0.2
       sax: 1.6.0
 
+  slash@5.1.0: {}
+
   smol-toml@1.7.0: {}
 
   source-map-js@1.2.1: {}
@@ -4330,10 +4645,19 @@ snapshots:
 
   stream-replace-string@2.0.0: {}
 
+  string-width@8.2.1:
+    dependencies:
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
   stringify-entities@4.0.4:
     dependencies:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
 
   strnum@2.4.1:
     dependencies:
@@ -4368,12 +4692,18 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
 
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
 
   tslib@2.8.1:
     optional: true
+
+  uc.micro@2.1.0: {}
 
   ufo@1.6.4: {}
 
@@ -4384,6 +4714,8 @@ snapshots:
   undici-types@7.18.2: {}
 
   undici-types@8.3.0: {}
+
+  unicorn-magic@0.4.0: {}
 
   unified@11.0.5:
     dependencies:

--- a/scripts/vale.sh
+++ b/scripts/vale.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Run Vale, using whatever is already on PATH; otherwise fetch the real
+# release binary into .bin/ and use that. Deliberately not npm/npx: the
+# npm-wrapped Vale packages (@vvago/vale) are known to fail with
+# "vale: command not found" even after a clean install, an npx
+# bin-resolution problem, not a broken download.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+if command -v vale >/dev/null 2>&1; then
+  VALE=vale
+else
+  BIN=".bin/vale"
+  if [ ! -x "$BIN" ]; then
+    mkdir -p .bin
+    case "$(uname -s)_$(uname -m)" in
+      Darwin_arm64)  pattern='*macOS_arm64.tar.gz' ;;
+      Darwin_x86_64) pattern='*macOS_64-bit.tar.gz' ;;
+      Linux_x86_64)  pattern='*Linux_64-bit.tar.gz' ;;
+      Linux_aarch64) pattern='*Linux_arm64.tar.gz' ;;
+      *) echo "vale.sh: unsupported platform $(uname -s)_$(uname -m)" >&2; exit 1 ;;
+    esac
+    echo "vale.sh: vale not on PATH, fetching a local copy into .bin/..." >&2
+    tmp="$(mktemp -d)"
+    gh release download --repo vale-cli/vale --pattern "$pattern" --output "$tmp/vale.tar.gz" --clobber
+    tar -xzf "$tmp/vale.tar.gz" -C .bin vale
+    rm -rf "$tmp"
+  fi
+  VALE="$BIN"
+fi
+
+if [ ! -d styles/Google ] || [ ! -d styles/write-good ] || [ ! -d styles/alex ]; then
+  "$VALE" sync
+fi
+
+exec "$VALE" "$@"

--- a/styles/DocsAssist/ClickHere.yml
+++ b/styles/DocsAssist/ClickHere.yml
@@ -1,0 +1,9 @@
+extends: existence
+message: "Use link text that describes the destination instead of '%s'."
+link: https://developers.google.com/style/cross-references
+level: warning
+ignorecase: true
+tokens:
+  - click here
+  - clicking here
+  - click this link

--- a/styles/DocsAssist/EmDash.yml
+++ b/styles/DocsAssist/EmDash.yml
@@ -1,0 +1,7 @@
+extends: existence
+message: "Avoid em dashes. Use a comma, a colon, parentheses, or rewrite the sentence."
+link: https://github.com/EdwardAngert/docs-agent-plugin
+level: error
+nonword: true
+tokens:
+  - '—'

--- a/styles/DocsAssist/FalseContrast.yml
+++ b/styles/DocsAssist/FalseContrast.yml
@@ -1,0 +1,12 @@
+extends: existence
+message: "Rewrite the 'it's not X, it's Y' contrast as a direct statement of the fact."
+link: https://github.com/EdwardAngert/docs-agent-plugin
+level: suggestion
+ignorecase: true
+nonword: true
+# Heuristic for the "it's not X, it's Y" / "not X, but Y" contrast pattern.
+# It can match legitimate technical prose ("if it's not configured, but a
+# default applies, ..."), so this is a suggestion, not an error: a prompt to
+# look at the sentence, not an automatic rewrite.
+tokens:
+  - '\b(?:not|isn''t|is not)\b[^.!?,;]{0,50},\s*(?:but\s+)?(?:it''s|it is|they''re|they are)\b'

--- a/styles/DocsAssist/FillerPhrase.yml
+++ b/styles/DocsAssist/FillerPhrase.yml
@@ -1,0 +1,17 @@
+extends: existence
+message: "'%s' is filler. Cut it and start with the instruction or fact."
+link: https://github.com/EdwardAngert/docs-agent-plugin
+level: warning
+ignorecase: true
+tokens:
+  - it's worth noting that
+  - it is worth noting that
+  - it's worth noting
+  - it is worth noting
+  - it's important to note that
+  - it is important to note that
+  - it's important to understand
+  - let's dive into
+  - let's take a look at
+  - needless to say
+  - at the end of the day

--- a/styles/DocsAssist/HeadingGerund.yml
+++ b/styles/DocsAssist/HeadingGerund.yml
@@ -1,0 +1,9 @@
+extends: existence
+message: "Use an imperative verb in headings, not a gerund (for example, 'Install the Plugin', not 'Installing the Plugin')."
+link: https://developers.google.com/style/headings
+level: warning
+scope: heading
+# Flags a heading that begins with an -ing word. Heuristic: it can match
+# legitimate nouns like "Engineering", so it is a warning, not an error.
+tokens:
+  - '^\s*\w+ing\b'

--- a/styles/DocsAssist/MarketingLanguage.yml
+++ b/styles/DocsAssist/MarketingLanguage.yml
@@ -1,0 +1,29 @@
+extends: existence
+message: "'%s' is marketing language, not a description. State what it does."
+link: https://github.com/EdwardAngert/docs-agent-plugin
+level: warning
+ignorecase: true
+# "leverage" is deliberately excluded: it doubles as a legitimate compound
+# noun in plenty of technical prose ("highest-leverage fix"), not just the
+# verb cliché ("leverage our platform"). A bare-word existence match can't
+# tell the two apart, so drop it here and catch the cliché by review instead.
+tokens:
+  - seamless
+  - seamlessly
+  - powerful
+  - robust
+  - cutting-edge
+  - cutting edge
+  - effortless
+  - effortlessly
+  - unlock
+  - elevate
+  - empower
+  - game-changing
+  - game changing
+  - revolutionize
+  - revolutionary
+  - best-in-class
+  - world-class
+  - unparalleled
+  - transformative


### PR DESCRIPTION
## Summary
- Bring over Docs Assist's opinionated markdownlint ruleset (`.markdownlint.jsonc`), extended to allow this site's Starlight/MDX components and the `kbd`/`p`/`em` tags actually used in content.
- Bring over the Vale `DocsAssist` style plus `.vale.ini` (Google/write-good/alex packages via `vale sync`), with `Google.Headings` off since this site uses title-case headings, and `.mdx` mapped to markdown format so Vale skips the unavailable `mdx2vast` converter.
- Add `scripts/vale.sh`: uses `vale` from `PATH` if present, otherwise fetches the real release binary locally into `.bin/` (the npm-wrapped vale packages are known unreliable).
- Add `lint:md`, `lint:vale`, and `lint` scripts to `package.json`; add `markdownlint-cli2` as a devDependency.
- `.gitignore`: exclude the synced `styles/{Google,write-good,alex}` packages and the local `.bin/vale` binary; `styles/DocsAssist/` stays tracked.

Both linters run clean against config; the only findings are pre-existing content issues (9 markdownlint, 11 Vale errors at `--minAlertLevel=error`) which are left for a follow-up, not touched here.

## Test plan
- [x] `pnpm lint:md` runs and reports only pre-existing content issues
- [x] `pnpm lint:vale` runs cold (no `vale` on `PATH`), fetches the binary and style packages, and reports the same findings
- [x] `pnpm build` still succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)