### PR TITLE
Update README and sync llms.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,24 @@
 # edwardangert.com
 
-My personal site showcasing technical writing work, documentation samples, and portfolio pieces.
+My personal site: technical writing samples, an independently maintained documentation set, and a blog.
 
 I bought the domain. Might as well use it.
 
 ## What's here
 
-- **Portfolio** - Technical writing samples and documentation projects
-- **Guides** - Full documentation sets (currently featuring a Pi-hole guide)
-- **About** - Resume and professional background
+- **Portfolio** ([`/portfolio/`](https://edwardangert.com/portfolio/)) - Documentation samples across Coder, GitLab, Linode, Pantheon, and an open-source Claude Code plugin.
+- **Pi-hole v6 Setup Guide** ([`/docs/pi-hole/`](https://edwardangert.com/docs/pi-hole/)) - A complete, independently maintained guide: OS setup and hardening, installation, blocklists and allowlists, network-wide DNS enforcement, Tailscale remote access, maintenance, and troubleshooting. It's become a heavily cited AI grounding source for Pi-hole questions.
+- **Blog** ([`/blog/`](https://edwardangert.com/blog/)) - Essays on documentation, AI, and the fundamentals that outlast the hype.
+- **About** ([`/about/resume/`](https://edwardangert.com/about/resume/)) - Resume and professional background.
 
 ## Built with
 
 - [Astro](https://astro.build) - Static site framework
 - [Starlight](https://starlight.astro.build) - Documentation theme
+- [starlight-blog](https://github.com/HiDeoo/starlight-blog) - Blog plugin
+- [starlight-fullview-mode](https://github.com/trueberryless-org/starlight-fullview-mode) - Full-view reading mode
 - [Catppuccin](https://catppuccin.com) - Color scheme (Mocha dark, Latte light)
+- [PostHog](https://posthog.com) - Site analytics
 
 ## Development
 
@@ -31,6 +35,26 @@ pnpm build
 # Preview production build
 pnpm preview
 ```
+
+## Linting
+
+The docs are linted for structure (markdownlint) and prose (Vale), configured in `.markdownlint.jsonc` and `.vale.ini`.
+
+```bash
+# Structural rules
+pnpm lint:md
+
+# Prose rules (fetches a local vale binary and the Google/write-good/alex
+# style packages on first run if they aren't already present)
+pnpm lint:vale
+
+# Both
+pnpm lint
+```
+
+## Agent-ready
+
+[`llms.txt`](https://edwardangert.com/llms.txt) and [`llms-full.txt`](https://edwardangert.com/llms-full.txt) give AI tools a map of the site and the full text of the Pi-hole guide.
 
 ## Live site
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -25,3 +25,4 @@ The full text of the guide is at https://edwardangert.com/llms-full.txt.
 - [Chasing the Meta: Fundamentals, Hype, and Progress](https://edwardangert.com/blog/chasing-meta/): On a broken MCP, jiu-jitsu meta, and why the fundamentals outlast every shiny new AI tool.
 - [The Riptide of AI Hype](https://edwardangert.com/blog/riptide-of-ai-hype/): On unverifiable AI promises, AI-washing, moving goalposts, and why the hype is a riptide, not a lie.
 - [Docs Assist: A Technical Writing Aide](https://edwardangert.com/blog/docs-assist-plugin/): A technical writer is a developer, too. How the Docs Assist Claude Code plugin handles the structural work so you can spend more time on technical writing.
+- [Who benefits from progress?](https://edwardangert.com/blog/progress-standards/): On the Cross-Bronx Expressway, Tesla's charging network, and the difference between a standard built for everyone and one that just gets called that.


### PR DESCRIPTION
## Summary
- Rewrites README.md to reflect the site's actual current sections (portfolio, Pi-hole v6 guide, blog, about), the dependencies actually in use (starlight-blog, starlight-fullview-mode, PostHog), the linting scripts added in a previous PR, and the llms.txt/llms-full.txt agent-ready files.
- Adds the missing "Who benefits from progress?" blog post to public/llms.txt.

## Test plan
- [x] `markdownlint-cli2 --config .markdownlint.jsonc README.md` reports 0 issues
- [x] `pnpm build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)