### PR TITLE
Update resume highlights and sync Pi-hole citation numbers

### DIFF
--- a/src/content/docs/about/resume.mdx
+++ b/src/content/docs/about/resume.mdx
@@ -16,17 +16,20 @@ For samples of the work itself, see the [portfolio](/portfolio/).
 
 - First dedicated and sole technical writer at Coder.
   - Top-5 contributor to the open-source repo within 90 days.
-  - Embedded quickly with product, engineering, and support.
+  - Audited fragmented docs and broken user journeys, built four user personas through card-sorting research, and redesigned the [Quickstart](/portfolio/coder-quickstart/) as the anchor of the new information architecture.
   - Prototyped AI-assisted contributor documentation workflows using Claude Code to organize content, analyze codebases, and draft documentation.
 - Scaled Pantheon's docs team.
   - Four writers served 200+ employees, a ~1:67 stakeholder ratio sustained through documentation culture and contributor pathways.
   - Built content operations infrastructure (style guide standards, automated linting, metrics) that stayed in use after I left.
+  - Standardized [Terminus](https://github.com/pantheon-systems/terminus) CLI and platform SDK documentation with OpenAPI-style parameter references, enabling customer scripting workflows.
+  - Authored end-to-end Drupal 9 platform documentation while pushing engineering toward a phased release approach, so documentable progress kept shipping despite backend blockers.
+  - Shaped in-product copy across the platform: interface labels, billing and payment flow text, and invoice language.
 - Presented documentation strategy to leadership to advocate for docs-as-code and build organizational buy-in.
 - Rewrote Linode's "Find Files in Linux" with useful, easier to find references and turned it into the highest-traffic page on linode.com and top Google search result.
 - Edited public-facing legal policies like MSAs, Terms of Use, and Scope of Supports.
-- [Pi-hole v6 guide](/docs/pi-hole/): a personal documentation project that became a leading AI grounding source for Pi-hole questions, roughly a 30% share of authority in Microsoft's AI Visibility data and 1,500+ citations a quarter.
-- [Docs Assist](https://github.com/EdwardAngert/docs-agent-plugin): an open-source Claude Code plugin to help solo technical writers and contributors implement my documentation methodology with reusable AI workflows.
-- [AI is coming for my job. Maybe to my job.](/blog/ai-docs-assist/), a dual-audience thesis on documentation for humans and AI systems.
+- [Pi-hole v6 guide](/docs/pi-hole/): a personal documentation project that became a leading AI grounding source for Pi-hole questions (~30% share of cited authority, Clarity AI visibility tracking; 3,000+ citations since March, under 1% referral).
+- [Docs Assist](/portfolio/docs-assist-plugin/): an open-source Claude Code plugin that encodes my technical writing methodology into an AI aide, for subject matter experts and for technical writers acting at scale.
+- [Blog](/blog/): essays on documentation, AI, and the fundamentals that outlast the hype.
 
 ## Career
 

--- a/src/content/docs/blog/docs-assist-plugin.mdx
+++ b/src/content/docs/blog/docs-assist-plugin.mdx
@@ -7,7 +7,7 @@ excerpt:
 ---
 
 I rewrote the [Pi-hole documentation](../pi-hole/) on my site in mid-March.
-Since then, according to metrics from Clarity, AI assistants have cited it over 2,000 times to answer other people's questions.
+Since then, according to metrics from Clarity, AI assistants have cited it over 3,000 times to answer other people's questions.
 
 Strangers, mid-troubleshooting, asking their AI `so how do i know if pihole works`, `getting 403 forbidden when trying to access pihole for the first time`, and `now ti says forbiden`.
 
@@ -187,7 +187,7 @@ I checked its claims against the code the way I'd check any SME's draft.)
 It probably won't replace a technical writer, which is good, because I still [need a job](../about/resume.mdx).
 But it does cover some of the tasks that slow an SME contributor and a technical writer down.
 
-Every hour I don't spend fixing nested markdown or looking for the most recent Slack conversation that decided a naming convention is time I can spend on the work that made those 2,000+ citations happen: knowing my audience and developing the architecture that gets them what they need.
+Every hour I don't spend fixing nested markdown or looking for the most recent Slack conversation that decided a naming convention is time I can spend on the work that made those 3,000+ citations happen: knowing my audience and developing the architecture that gets them what they need.
 
 Whether the last hop to that human is a search engine, a docs site, or an AI reading on their behalf, I'm happy knowing they got their answer.
 

--- a/src/content/docs/portfolio/index.mdx
+++ b/src/content/docs/portfolio/index.mdx
@@ -6,7 +6,7 @@ description: "Documentation samples across different organizations and project t
 
 import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
-<LinkCard title="Pi-hole v6 Documentation" href="/docs/pi-hole/" description="A Pi-hole v6 project I built and maintain end to end, written for my own network.<br />It's quietly become a leading AI grounding source for Pi-hole questions: roughly a 30% share of authority in Microsoft's AI Visibility data and 1,500+ citations a quarter. Most of that traffic comes from AI crawlers rather than human readers, which is a strange-feeling win when your audience's whole goal is blocking trackers." />
+<LinkCard title="Pi-hole v6 Documentation" href="/docs/pi-hole/" description="A Pi-hole v6 project I built and maintain end to end, written for my own network.<br />It's quietly become a leading AI grounding source for Pi-hole questions: roughly a 30% share of cited authority (Clarity AI visibility tracking) and 3,000+ citations since March, under 1% referral. Most of that traffic comes from AI crawlers rather than human readers, which is a strange-feeling win when your audience's whole goal is blocking trackers." />
 
 <LinkCard title="Docs Assist: A Claude Code Plugin" href="/portfolio/docs-assist-plugin/" description="An open-source Claude Code plugin that encodes my technical writing methodology into an AI aide that gathers, structures, and verifies documentation, guided by a subject matter expert or writer rather than left to guess." />
 


### PR DESCRIPTION
## Summary
- Resume: Docs Assist now links to its portfolio page instead of raw GitHub; the single aging blog-post link is replaced with a link to /blog/.
- Resume: adds highlights from the resume PDF that weren't yet on the site (Pantheon's Terminus/SDK doc standardization, phased release strategy under blockers, in-product UX copy; sharpened the Coder highlight to the concrete IA/persona/Quickstart work, linked to the existing portfolio page).
- Syncs the Pi-hole AI citation stats across the resume, the portfolio index card, and the "Docs Assist" blog post to a fresh Clarity pull: ~30% share of cited authority, 3,000+ citations since March, under 1% referral. These three spots previously carried three different, inconsistent numbers.

## Test plan
- [x] `pnpm lint:md` and `pnpm lint:vale --minAlertLevel=error` report no new findings
- [x] `pnpm build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)