### PR TITLE
Make Docs Assist plugin description consistent

### DIFF
--- a/src/content/docs/portfolio/docs-assist-plugin.mdx
+++ b/src/content/docs/portfolio/docs-assist-plugin.mdx
@@ -1,13 +1,13 @@
 ---
 slug: portfolio/docs-assist-plugin
 title: "Docs Assist: A Claude Code Plugin"
-description: "Open-source Claude Code plugin that codifies my documentation methodology into reusable AI workflows"
+description: "Open-source Claude Code plugin built for calibrated AI use: coaches SMEs through writing docs, verifies claims against source, and runs a dependency-free CI check"
 icon: "rocket"
 category: "Open Source / AI Tooling"
 externalLink: "https://github.com/EdwardAngert/docs-agent-plugin"
 ---
 
-[Docs Assist](https://github.com/EdwardAngert/docs-agent-plugin) is a Claude Code plugin I built and maintain that encodes my technical writing methodology into a repeatable process, so an AI model applies it consistently instead of leaving it up to whoever's prompting that day.
+[Docs Assist](https://github.com/EdwardAngert/docs-agent-plugin) is a Claude Code plugin I built and maintain for calibrated AI use: it encodes my technical writing methodology into a repeatable process, verifies its own claims against source instead of taking them on faith, and reserves the model for judgment calls rather than running it on everything.
 
 <dl>
   <dt>For a subject matter expert (engineer, PM, or support team)</dt>
@@ -19,13 +19,13 @@ externalLink: "https://github.com/EdwardAngert/docs-agent-plugin"
 ## What It Does
 
 No slash command needed, the plugin activates from plain conversation the moment you ask for documentation help.
-It gathers before it structures, plans a whole documentation set before writing a word, flags what it can't verify instead of guessing, keeps writing rules and lint rules in one committed config file so the two can't drift apart, updates every affected doc when code changes, and makes docs agent-ready (`llms.txt`, frontmatter, repo conventions), the same mechanism behind the [Pi-hole documentation](/docs/pi-hole/) on this site picking up thousands of AI citations a quarter.
+It gathers before it structures, plans a whole documentation set before writing a word, verifies claims against source and flags what it can't confirm instead of guessing, keeps writing rules and lint rules in one committed config file so the two can't drift apart, updates every affected doc when code changes, and makes docs agent-ready (`llms.txt`, frontmatter, repo conventions), the same mechanism behind the [Pi-hole documentation](/docs/pi-hole/) on this site picking up thousands of AI citations a quarter.
 
 The design principle underneath: use the model only where judgment is required, and deterministic tools everywhere else.
 An optional CI check, for example, never calls a model; it's a dependency-free script that flags which pull requests likely broke the docs and names the exact range to review, so the expensive model call only runs when a human decides it's warranted.
 
-I've also run it against real, external codebases, both ones I already knew well (Coder's networking internals, Pantheon's Terminus CLI) and ones I didn't, to test that it scales a technical writer's judgment as much as it coaches an SME's.
-Those were practice runs on other teams' repos, not linked here, but they're what the summary above is built on.
+I've exercised it across four codebases, both ones I already knew well (Coder's networking internals, Pantheon's Terminus CLI) and ones I didn't, to test that it scales a technical writer's judgment as much as it coaches an SME's.
+One of those runs was a 453-claim audit that caught 6 real doc/code drifts, cases where the documentation and the code had quietly disagreed. Those were practice runs on other teams' repos, not linked here, but they're what the summary above is built on.
 
 ## Background
 

--- a/src/content/docs/portfolio/index.mdx
+++ b/src/content/docs/portfolio/index.mdx
@@ -8,7 +8,7 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
 <LinkCard title="Pi-hole v6 Documentation" href="/docs/pi-hole/" description="A Pi-hole v6 project I built and maintain end to end, written for my own network.<br />It's quietly become a leading AI grounding source for Pi-hole questions: roughly a 30% share of cited authority (Clarity AI visibility tracking) and 3,000+ citations since March, under 1% referral. Most of that traffic comes from AI crawlers rather than human readers, which is a strange-feeling win when your audience's whole goal is blocking trackers." />
 
-<LinkCard title="Docs Assist: A Claude Code Plugin" href="/portfolio/docs-assist-plugin/" description="An open-source Claude Code plugin that encodes my technical writing methodology into an AI aide that gathers, structures, and verifies documentation, guided by a subject matter expert or writer rather than left to guess." />
+<LinkCard title="Docs Assist: A Claude Code Plugin" href="/portfolio/docs-assist-plugin/" description="An open-source Claude Code plugin built for calibrated AI use: it coaches SMEs through writing docs and verifies claims against source rather than guessing. Exercised across four codebases, including a 453-claim audit that caught 6 real doc/code drifts." />
 
 <CardGrid>
   <LinkCard title="Coder Quickstart Documentation" href="/portfolio/coder-quickstart/" description="Created quickstart guide to unlock Coder for new users. Part of a broader information architecture effort to define user journeys and personas." />


### PR DESCRIPTION
## Summary
- Portfolio detail page (`portfolio/docs-assist-plugin.mdx`) and index card (`portfolio/index.mdx`) now describe the plugin with the same specifics: built for calibrated AI use, verifies claims against source, and the 453-claim audit that caught 6 real doc/code drifts.
- No content changes to the resume page or blog posts — checked both for conflicts and found none.

## Test plan
- [ ] Preview both pages to confirm copy reads cleanly and links still resolve