### PR TITLE
Fix missing item field on current-page breadcrumb

### DIFF
--- a/src/components/Breadcrumbs.astro
+++ b/src/components/Breadcrumbs.astro
@@ -109,7 +109,9 @@ const breadcrumbs = generateBreadcrumbs(pathname);
  * Skipped on blog posts: starlight-blog already emits its own BreadcrumbList
  * there, and two competing trails for one page is worse than one.
  * `item` is omitted for entries that are not real pages, which is what
- * schema.org expects for a crumb with nothing to link to.
+ * schema.org expects for a crumb with nothing to link to. The current page
+ * still gets an `item` pointing at its own URL: Google Search Console flags
+ * a trailing crumb without one as a missing required field.
  */
 const site = Astro.site?.origin ?? '';
 const emitStructuredData = !pathname.startsWith('/blog/');
@@ -120,7 +122,7 @@ const breadcrumbJsonLd = {
     '@type': 'ListItem',
     position: index + 1,
     name: item.label,
-    ...(item.linkable && index < breadcrumbs.length - 1
+    ...(item.linkable
       ? { item: `${site}${item.href === '/' ? '/' : `${item.href}/`}` }
       : {}),
   })),


### PR DESCRIPTION
## Summary
- Google Search Console flagged BreadcrumbList structured data with a missing `item` field on `itemListElement`
- Root cause: `Breadcrumbs.astro` stripped `item` from the last crumb (the current page) even though it's a real, linkable URL, only non-page structural segments (like `/docs`) should omit it
- Fix: drop the position-based condition, keep `item` whenever the crumb is linkable

## Test plan
- [x] `pnpm build` succeeds
- [x] Verified generated JSON-LD on `/docs/pi-hole/block-allow-lists/`: current-page crumb now includes `item`, structural `/docs` crumb still omits it