### PR TITLE
Document Pi-hole hardening: SSH, auto-updates, and disk space

### DIFF
--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -477,7 +477,7 @@ Before you continue, confirm the following:
 - UFW is active with Pi-hole rules: `sudo ufw status`.
 - Fail2Ban is protecting SSH: `sudo fail2ban-client status sshd`.
 - The Pi has a static IP that won't change on reboot.
-- If you run into issues, see [Common Pi-hole Issues](./troubleshooting/#pi-hole-installation).
+- If you run into issues, see [Common Pi-hole Issues](./troubleshooting/#troubleshoot-pi-hole-installation-issues).
 
 The next page covers installing Pi-hole, configuring DNS, and optionally adding unbound for recursive resolution and Netdata for monitoring.
 
@@ -720,7 +720,7 @@ Before you continue to blocklists and allowlists to control what gets blocked, c
 - DNS queries are appearing in the query log.
 - The default blocklist is active.
   You can check **Gravity** in the Pi-hole dashboard to confirm.
-- If you run into issues, see [Common Pi-hole Issues](./troubleshooting/#pi-hole-installation).
+- If you run into issues, see [Common Pi-hole Issues](./troubleshooting/#troubleshoot-pi-hole-installation-issues).
 
 
 ---

--- a/src/content/docs/pi-hole/install-configure.mdx
+++ b/src/content/docs/pi-hole/install-configure.mdx
@@ -313,10 +313,10 @@ This helps minimize the risk of brute-force attacks.
 
 </Steps>
 
-### Disable Unused SSH Features
+### Disable X11 Forwarding
 
 SSH supports X11 forwarding, which lets a remote graphical app display on your local machine over the SSH connection.
-The Pi doesn't need this if you already have a screen attached, or if you don't run graphical apps over SSH.
+The Pi doesn't need this if you already have a display attached, or if you don't run graphical apps over SSH.
 
 <Steps>
 
@@ -453,6 +453,6 @@ Before you continue, confirm the following:
 - Fail2Ban is protecting SSH: `sudo fail2ban-client status sshd`.
 - Automatic security updates are enabled: `systemctl is-enabled unattended-upgrades`.
 - The Pi has a static IP that won't change on reboot.
-- If you run into issues, see [Common Pi-hole Issues](/docs/pi-hole/troubleshooting/#pi-hole-installation).
+- If you run into issues, see [Common Pi-hole Issues](/docs/pi-hole/troubleshooting/#troubleshoot-pi-hole-installation-issues).
 
 The next page covers installing Pi-hole, configuring DNS, and optionally adding unbound for recursive resolution and Netdata for monitoring.

--- a/src/content/docs/pi-hole/install-configure.mdx
+++ b/src/content/docs/pi-hole/install-configure.mdx
@@ -313,6 +313,58 @@ This helps minimize the risk of brute-force attacks.
 
 </Steps>
 
+### Disable Unused SSH Features
+
+SSH supports X11 forwarding, which lets a remote graphical app display on your local machine over the SSH connection.
+The Pi doesn't need this if you already have a screen attached, or if you don't run graphical apps over SSH.
+
+<Steps>
+
+1. Create a drop-in config to disable it:
+
+   ```ini title="/etc/ssh/sshd_config.d/60-disable-x11-forwarding.conf"
+   X11Forwarding no
+   ```
+
+1. Reload SSH to apply the change:
+
+   ```shell title="From the Pi"
+   sudo systemctl reload sshd
+   ```
+
+</Steps>
+
+### Enable Automatic Security Updates
+
+Pi-hole is DNS infrastructure for your whole network, so it's worth patching promptly rather than waiting until you remember to run `apt upgrade`.
+`unattended-upgrades` installs security patches automatically.
+
+<Steps>
+
+1. Install `unattended-upgrades`:
+
+   ```shell title="From the Pi"
+   sudo apt install -y unattended-upgrades
+   ```
+
+1. Debian's package defaults already enable security-origin updates and leave automatic reboots off.
+   Confirm both:
+
+   ```shell title="From the Pi"
+   grep -A2 "Allowed-Origins" /etc/apt/apt.conf.d/50unattended-upgrades && grep "Automatic-Reboot \"" /etc/apt/apt.conf.d/50unattended-upgrades
+   ```
+
+   Leave automatic reboot commented out (disabled) unless you specifically want the Pi to reboot itself after a kernel update.
+   For a DNS server, rebooting on your own schedule is usually safer.
+
+1. Confirm the service is enabled, then do a dry run to see what it would install:
+
+   ```shell title="From the Pi"
+   systemctl is-enabled unattended-upgrades && sudo unattended-upgrade --dry-run --debug
+   ```
+
+</Steps>
+
 ### Set a Static IP Address
 
 Pi-hole needs a stable IP address.
@@ -399,6 +451,7 @@ Before you continue, confirm the following:
 - SSH access works: `ssh pi-admin@pi-hole.local`.
 - UFW is active with Pi-hole rules: `sudo ufw status`.
 - Fail2Ban is protecting SSH: `sudo fail2ban-client status sshd`.
+- Automatic security updates are enabled: `systemctl is-enabled unattended-upgrades`.
 - The Pi has a static IP that won't change on reboot.
 - If you run into issues, see [Common Pi-hole Issues](/docs/pi-hole/troubleshooting/#pi-hole-installation).
 

--- a/src/content/docs/pi-hole/maintenance.mdx
+++ b/src/content/docs/pi-hole/maintenance.mdx
@@ -88,11 +88,41 @@ This is the full `pihole.toml` from my setup, with comments stripped and the pas
 Values marked `### CHANGED` were modified from the Pi-hole default.
 
 <details>
-<summary>pihole.toml (v6.5, comments stripped)</summary>
+<summary>pihole.toml (v6.7, comments stripped)</summary>
 
 <Code code={piholeToml} lang="toml" />
 
 </details>
+
+## Prevent Disk Space Issues
+
+An SD card can fill up from things that have nothing to do with Pi-hole itself.
+`apt` caches every package it downloads in `/var/cache/apt/archives` and never cleans up superseded versions on its own.
+If you installed [Netdata](/docs/pi-hole/pihole-install/#optional-monitor-pi-hole-with-netdata) without the `--stable-channel` flag, this is a real risk: the nightly channel ships a new build every day, `apt-daily-upgrade.timer` installs it automatically, and the old one just sits in the cache. That's roughly 100-150MB accumulating per day with no ceiling, which can fill an SD card in a few weeks.
+
+<Steps>
+
+1. Check how much the apt cache is currently using:
+
+   ```shell title="From the Pi"
+   sudo du -sh /var/cache/apt/archives
+   ```
+
+1. Clear what's already there:
+
+   ```shell title="From the Pi"
+   sudo apt-get clean
+   ```
+
+1. Configure apt to clean up superseded packages weekly on its own:
+
+   ```ini title="/etc/apt/apt.conf.d/00-autoclean"
+   APT::Periodic::AutocleanInterval "7";
+   ```
+
+</Steps>
+
+If you're already on Netdata's nightly channel and want to switch, see [Monitor Pi-hole with Netdata](/docs/pi-hole/pihole-install/#optional-monitor-pi-hole-with-netdata) - reinstalling with `--stable-channel --reinstall` moves you over without losing your dashboard configuration.
 
 ## Offload Logs to a USB Drive
 

--- a/src/content/docs/pi-hole/maintenance.mdx
+++ b/src/content/docs/pi-hole/maintenance.mdx
@@ -13,6 +13,7 @@ next:
 
 import { Steps, Code } from '@astrojs/starlight/components';
 import piholeToml from './pihole.toml.example?raw';
+export const highlights = ["<redacted>", "### CHANGED"];
 
 After the Pi is set up and running, use this page as a reference for [running manual updates](#update-pi-hole), configuring [backups](#back-up-your-configuration) of your Pi configuration, or to [use a USB drive to store logs](#offload-logs-to-a-usb-drive).
 
@@ -90,39 +91,9 @@ Values marked `### CHANGED` were modified from the Pi-hole default.
 <details>
 <summary>pihole.toml (v6.7, comments stripped)</summary>
 
-<Code code={piholeToml} lang="toml" />
+<Code code={piholeToml} lang="toml" mark={highlights} />
 
 </details>
-
-## Prevent Disk Space Issues
-
-An SD card can fill up from things that have nothing to do with Pi-hole itself.
-`apt` caches every package it downloads in `/var/cache/apt/archives` and never cleans up superseded versions on its own.
-If you installed [Netdata](/docs/pi-hole/pihole-install/#optional-monitor-pi-hole-with-netdata) without the `--stable-channel` flag, this is a real risk: the nightly channel ships a new build every day, `apt-daily-upgrade.timer` installs it automatically, and the old one just sits in the cache. That's roughly 100-150MB accumulating per day with no ceiling, which can fill an SD card in a few weeks.
-
-<Steps>
-
-1. Check how much the apt cache is currently using:
-
-   ```shell title="From the Pi"
-   sudo du -sh /var/cache/apt/archives
-   ```
-
-1. Clear what's already there:
-
-   ```shell title="From the Pi"
-   sudo apt-get clean
-   ```
-
-1. Configure apt to clean up superseded packages weekly on its own:
-
-   ```ini title="/etc/apt/apt.conf.d/00-autoclean"
-   APT::Periodic::AutocleanInterval "7";
-   ```
-
-</Steps>
-
-If you're already on Netdata's nightly channel and want to switch, see [Monitor Pi-hole with Netdata](/docs/pi-hole/pihole-install/#optional-monitor-pi-hole-with-netdata) - reinstalling with `--stable-channel --reinstall` moves you over without losing your dashboard configuration.
 
 ## Offload Logs to a USB Drive
 

--- a/src/content/docs/pi-hole/pihole-install.mdx
+++ b/src/content/docs/pi-hole/pihole-install.mdx
@@ -180,6 +180,7 @@ To fix: configure unbound on port 5335 as above, then restart both:
 sudo systemctl restart unbound
 sudo systemctl restart pihole-FTL
 ```
+
 :::
 
 ## Optional: Monitor Pi-hole with Netdata
@@ -192,7 +193,7 @@ Add Netdata if you want system-level metrics alongside your Pi-hole data.
 
 <Steps>
 
-1. Install Netdata on the **stable** release channel:
+1. Install Netdata on the stable release channel:
 
    ```shell title="From the Pi"
    curl https://get.netdata.cloud/kickstart.sh > /tmp/netdata-kickstart.sh && sh /tmp/netdata-kickstart.sh --stable-channel --disable-telemetry
@@ -201,13 +202,6 @@ Add Netdata if you want system-level metrics alongside your Pi-hole data.
    The installer takes a few minutes.
 
    When it finishes, Netdata starts automatically and auto-discovers Pi-hole.
-
-   :::caution["Use --stable-channel, not the default"]
-   Without this flag, the kickstart script defaults to the **nightly** channel, which ships a new build daily.
-   `apt-daily-upgrade.timer` installs each one automatically, and apt never cleans up the superseded packages on its own - on an SD card, that's roughly 100-150MB of accumulated cache per day with no ceiling.
-   Left unchecked, this alone can fill the SD card over a few weeks.
-   See [Prevent Disk Space Issues](/docs/pi-hole/maintenance/#prevent-disk-space-issues) to also clean up whatever nightly packages may have already accumulated, and to stop apt's cache from growing unbounded regardless of release channel.
-   :::
 
 1. Allow the dashboard port through UFW if you want access from other devices on your network:
 
@@ -256,4 +250,4 @@ Before you continue to blocklists and allowlists to control what gets blocked, c
 - DNS queries are appearing in the query log.
 - The default blocklist is active.
   You can check **Gravity** in the Pi-hole dashboard to confirm.
-- If you run into issues, see [Common Pi-hole Issues](/docs/pi-hole/troubleshooting/#pi-hole-installation).
+- If you run into issues, see [Common Pi-hole Issues](/docs/pi-hole/troubleshooting/#troubleshoot-pi-hole-installation-issues).

--- a/src/content/docs/pi-hole/pihole-install.mdx
+++ b/src/content/docs/pi-hole/pihole-install.mdx
@@ -192,15 +192,22 @@ Add Netdata if you want system-level metrics alongside your Pi-hole data.
 
 <Steps>
 
-1. Install Netdata:
+1. Install Netdata on the **stable** release channel:
 
    ```shell title="From the Pi"
-   curl https://get.netdata.cloud/kickstart.sh > /tmp/netdata-kickstart.sh && sh /tmp/netdata-kickstart.sh --disable-telemetry
+   curl https://get.netdata.cloud/kickstart.sh > /tmp/netdata-kickstart.sh && sh /tmp/netdata-kickstart.sh --stable-channel --disable-telemetry
    ```
 
    The installer takes a few minutes.
 
    When it finishes, Netdata starts automatically and auto-discovers Pi-hole.
+
+   :::caution["Use --stable-channel, not the default"]
+   Without this flag, the kickstart script defaults to the **nightly** channel, which ships a new build daily.
+   `apt-daily-upgrade.timer` installs each one automatically, and apt never cleans up the superseded packages on its own - on an SD card, that's roughly 100-150MB of accumulated cache per day with no ceiling.
+   Left unchecked, this alone can fill the SD card over a few weeks.
+   See [Prevent Disk Space Issues](/docs/pi-hole/maintenance/#prevent-disk-space-issues) to also clean up whatever nightly packages may have already accumulated, and to stop apt's cache from growing unbounded regardless of release channel.
+   :::
 
 1. Allow the dashboard port through UFW if you want access from other devices on your network:
 

--- a/src/content/docs/pi-hole/pihole.toml.example
+++ b/src/content/docs/pi-hole/pihole.toml.example
@@ -1,4 +1,4 @@
-# Pi-hole configuration file (v6.5)
+# Pi-hole configuration file (v6.7)
 # Reference config - comments stripped, default values preserved for reference.
 # Values marked ### CHANGED were modified from the Pi-hole default.
 # To apply: copy to /etc/pihole/pihole.toml, then sudo systemctl restart pihole-FTL
@@ -10,7 +10,7 @@
   ] ### CHANGED, default = []
   CNAMEdeepInspect = true
   blockESNI = true
-  EDNS0ECS = true
+  EDNS0ECS = false ### CHANGED, default = true
   ignoreLocalhost = false
   showDNSSEC = true
   analyzeOnlyAandAAAA = false
@@ -24,7 +24,7 @@
   dnssec = false
   interface = "eth0" ### CHANGED, default = ""
   hostRecord = ""
-  listeningMode = "LOCAL"
+  listeningMode = "ALL" ### CHANGED, default = "LOCAL"
   queryLogging = true
   cnameRecords = []
   port = 53
@@ -91,7 +91,7 @@
     address = ""
 
   [ntp.sync]
-    active = true
+    active = false ### CHANGED, default = true
     server = "pool.ntp.org"
     interval = 3600
     count = 8
@@ -104,6 +104,7 @@
 [resolver]
   resolveIPv4 = true
   resolveIPv6 = true
+  macNames = true
   networkNames = true
   refreshNames = "IPV4_ONLY"
 
@@ -125,7 +126,7 @@
   threads = 50
   headers = [
     "X-DNS-Prefetch-Control: off",
-    "Content-Security-Policy: default-src 'none'; connect-src 'self'; font-src 'self'; frame-ancestors 'none'; img-src 'self'; manifest-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'",
+    "Content-Security-Policy: default-src 'none'; connect-src 'self'; font-src 'self'; frame-ancestors 'none'; img-src 'self'; manifest-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; form-action 'self'",
     "X-Frame-Options: DENY",
     "X-XSS-Protection: 0",
     "X-Content-Type-Options: nosniff",
@@ -154,7 +155,7 @@
   [webserver.api]
     max_sessions = 16
     prettyJSON = false
-    pwhash = "" ### CHANGED from default (use `sudo pihole setpassword` to set)
+    pwhash = "<redacted>" ### CHANGED from default (use `sudo pihole setpassword` to set)
     totp_secret = ""
     app_pwhash = ""
     app_sudo = false
@@ -171,7 +172,6 @@
       unit = "C"
 
 [files]
-  pid = "/run/pihole-FTL.pid"
   database = "/etc/pihole/pihole-FTL.db"
   tmp_db = "/etc/pihole/pihole-tmp.db"
   gravity = "/etc/pihole/gravity.db"
@@ -233,4 +233,5 @@
   ntp = false
   netlink = false
   timing = false
+  performance = false
   all = false

--- a/src/content/docs/pi-hole/troubleshooting.mdx
+++ b/src/content/docs/pi-hole/troubleshooting.mdx
@@ -22,6 +22,12 @@ sudo systemctl restart pihole-FTL
 
 Change `true` to `false` when you're done troubleshooting.
 
+### Sharing a Debug Log for Support
+
+`pihole -d` collects a debug log and asks before uploading it anywhere.
+`pihole -d -a` runs in automated mode, which skips that prompt and uploads straight to `tricorder.pi-hole.net` for developer support.
+The log auto-deletes after 48 hours and isn't tied to any account, but it's still your query and network data leaving the device - use plain `pihole -d` if you want to review the log first.
+
 ## Pi-hole Installation
 
 ### SSH host key mismatch after rebuild
@@ -176,9 +182,10 @@ If this returns `SERVFAIL` or times out, the problem is in unbound, not FTL.
 
 **Fix - refresh root hints**:
 
+`unbound-anchor` isn't included when you `apt install unbound` - install it separately first:
+
 ```shell title="From the Pi"
-sudo unbound-anchor -a /var/lib/unbound/root.key
-sudo systemctl restart unbound
+sudo apt install unbound-anchor && sudo unbound-anchor -a /var/lib/unbound/root.key && sudo systemctl restart unbound
 ```
 
 **Fix - check unbound logs**:
@@ -219,6 +226,21 @@ maxDBdays = 91
 Lower this further if disk space is a concern.
 
 Refer to the [example pihole.toml](/docs/pi-hole/maintenance/#reference-full-piholetoml) in the maintenance section for a full `pihole.toml` reference.
+
+### Disk fills up and it's not the FTL database
+
+**Symptom**: Disk usage climbs toward 100% over days or weeks, but `pihole-FTL.db` is nowhere near large enough to explain it.
+
+**Common cause**: Netdata installed on the nightly release channel instead of stable.
+Nightly ships a new build daily, `apt-daily-upgrade.timer` installs it automatically, and apt never cleans up the superseded packages in `/var/cache/apt/archives` on its own - roughly 100-150MB accumulates per day with no ceiling.
+
+**Check**:
+
+```shell title="From the Pi"
+sudo du -sh /var/cache/apt/archives && apt list --installed 2>/dev/null | grep nightly
+```
+
+**Fix**: see [Prevent Disk Space Issues](/docs/pi-hole/maintenance/#prevent-disk-space-issues) to clear the cache, stop it from recurring, and optionally move Netdata to the stable channel.
 
 ### NTP warnings in the Pi-hole dashboard
 
@@ -360,6 +382,15 @@ If a source goes dark, replace it.
 Projects rename tiers and reorganize files.
 For example, 1Hosts renamed `Pro` to `Xtra` in 2025, breaking old URLs.
 If a URL 404s, check the project's README for current links before assuming the project is dead.
+
+#### "List ID was inaccessible during last gravity run" warning won't go away
+
+If you previously added a bare domain name as a list URL (see "Invalid protocol" above) and later fixed it by moving the domain to **Domains** > **Allowlist**, FTL can keep showing the old warning for that list ID until it restarts, even though a fresh `sudo pihole -g` runs clean.
+
+**Check**: run `sudo pihole -g` and confirm no errors appear for the current run.
+If it's clean, the warning is stale.
+
+**Fix**: `sudo systemctl restart pihole-FTL` clears it.
 
 ## Tailscale
 

--- a/src/content/docs/pi-hole/troubleshooting.mdx
+++ b/src/content/docs/pi-hole/troubleshooting.mdx
@@ -24,7 +24,7 @@ Change `true` to `false` when you're done troubleshooting.
 
 ### How to Create and Share a Pi-hole Debug Log for Support
 
-This diagnoses Pi-hole configuration and errors that appear in the admin dashboard's **Tools** > **Pi-hole diagnosis** (<https://pi-hole.local/admin/messages>).
+This diagnoses Pi-hole configuration and errors that appear in the admin dashboard's **Tools** > **Pi-hole diagnosis** (`https://pi-hole.local/admin/messages`).
 It does not diagnose errors in your operating system or networking configuration.
 
 Your Pi-hole device and installation need to be functional for the command to work.

--- a/src/content/docs/pi-hole/troubleshooting.mdx
+++ b/src/content/docs/pi-hole/troubleshooting.mdx
@@ -22,13 +22,39 @@ sudo systemctl restart pihole-FTL
 
 Change `true` to `false` when you're done troubleshooting.
 
-### Sharing a Debug Log for Support
+### How to Create and Share a Pi-hole Debug Log for Support
 
-`pihole -d` collects a debug log and asks before uploading it anywhere.
-`pihole -d -a` runs in automated mode, which skips that prompt and uploads straight to `tricorder.pi-hole.net` for developer support.
-The log auto-deletes after 48 hours and isn't tied to any account, but it's still your query and network data leaving the device - use plain `pihole -d` if you want to review the log first.
+This diagnoses Pi-hole configuration and errors that appear in the admin dashboard's **Tools** > **Pi-hole diagnosis** (<https://pi-hole.local/admin/messages>).
+It does not diagnose errors in your operating system or networking configuration.
 
-## Pi-hole Installation
+Your Pi-hole device and installation need to be functional for the command to work.
+
+<Steps>
+
+1. Collect a debug log for your Pi-hole:
+
+   ```shell title="From the Pi"
+   sudo pihole -d
+   ```
+
+1. After `pihole -d` collects the diagnostics, it asks if you want to upload the log to the official Pi-hole support server at `tricorder.pi-hole.net`:
+
+   ```shellsession title="From the Pi"
+   [?] Would you like to upload the log? [y/N]
+   ```
+
+   Enter <kbd>y</kbd> to upload the log.
+   The server automatically deletes the log file after 48 hours and isn't tied to any account.
+
+1. Log in to your account on the Pi-hole forum or create a new account then go to the [Help category](https://discourse.pi-hole.net/c/bugs-problems-issues/11) and select **New Topic**.
+
+1. Read and follow the template in the popup, and include a description of the problem you're seeing and the debug token.
+
+</Steps>
+
+For more information about Pi-hole debugging, visit the [official Pi-hole forum](https://discourse.pi-hole.net/t/how-do-i-debug-my-pi-hole-installation/3104).
+
+## Troubleshoot Pi-hole Installation Issues
 
 ### SSH host key mismatch after rebuild
 
@@ -101,7 +127,7 @@ sudo systemctl status pihole-FTL
 sudo journalctl -u pihole-FTL -n 50
 ```
 
-The most common reason on a fresh install is a port 53 conflict - see above.
+The most common reason on a fresh install is a port 53 conflict - see [Port 53 conflict between Pi-hole and unbound](#port-53-conflict-between-pi-hole-and-unbound).
 
 ### Gravity fails to update
 
@@ -180,6 +206,14 @@ dig google.com @127.0.0.1 -p 5335
 
 If this returns `SERVFAIL` or times out, the problem is in unbound, not FTL.
 
+**Check - unbound logs**:
+
+```shell title="From the Pi"
+sudo journalctl -u unbound -n 100
+```
+
+Look for `SERVFAIL`, timeout, or `DNSSEC` validation failure messages.
+
 **Fix - refresh root hints**:
 
 `unbound-anchor` isn't included when you `apt install unbound` - install it separately first:
@@ -187,14 +221,6 @@ If this returns `SERVFAIL` or times out, the problem is in unbound, not FTL.
 ```shell title="From the Pi"
 sudo apt install unbound-anchor && sudo unbound-anchor -a /var/lib/unbound/root.key && sudo systemctl restart unbound
 ```
-
-**Fix - check unbound logs**:
-
-```shell title="From the Pi"
-sudo journalctl -u unbound -n 100
-```
-
-Look for `SERVFAIL`, timeout, or `DNSSEC` validation failure messages.
 
 ### FTL database grows too large and FTL fails to start
 
@@ -227,12 +253,12 @@ Lower this further if disk space is a concern.
 
 Refer to the [example pihole.toml](/docs/pi-hole/maintenance/#reference-full-piholetoml) in the maintenance section for a full `pihole.toml` reference.
 
-### Disk fills up and it's not the FTL database
+### "Disk shortage ahead" - Netdata fills up disk space
 
-**Symptom**: Disk usage climbs toward 100% over days or weeks, but `pihole-FTL.db` is nowhere near large enough to explain it.
+**Symptom**: Netdata is installed and disk usage climbs unexpectedly.
 
 **Common cause**: Netdata installed on the nightly release channel instead of stable.
-Nightly ships a new build daily, `apt-daily-upgrade.timer` installs it automatically, and apt never cleans up the superseded packages in `/var/cache/apt/archives` on its own - roughly 100-150MB accumulates per day with no ceiling.
+Nightly ships a new build daily, `apt-daily-upgrade.timer` installs it automatically, and apt never cleans up the superseded packages in `/var/cache/apt/archives` on its own.
 
 **Check**:
 
@@ -240,7 +266,30 @@ Nightly ships a new build daily, `apt-daily-upgrade.timer` installs it automatic
 sudo du -sh /var/cache/apt/archives && apt list --installed 2>/dev/null | grep nightly
 ```
 
-**Fix**: see [Prevent Disk Space Issues](/docs/pi-hole/maintenance/#prevent-disk-space-issues) to clear the cache, stop it from recurring, and optionally move Netdata to the stable channel.
+**Fix**: Clear the cache, stop it from recurring, and move Netdata to the stable channel.
+
+<Steps>
+
+1. Clear the apt cache:
+
+   ```shell title="From the Pi"
+   sudo apt clean
+   ```
+
+1. Configure apt to clean up superseded packages weekly on its own:
+
+   ```ini title="/etc/apt/apt.conf.d/00-autoclean"
+   APT::Periodic::AutocleanInterval "7";
+   ```
+
+1. Switch to the Netdata stable channel:
+
+   ```shell title="From the Pi"
+   wget -O /tmp/netdata-kickstart.sh https://get.netdata.cloud/kickstart.sh && \
+   sh /tmp/netdata-kickstart.sh --reinstall --stable-channel --disable-telemetry
+   ```
+
+</Steps>
 
 ### NTP warnings in the Pi-hole dashboard
 
@@ -385,7 +434,7 @@ If a URL 404s, check the project's README for current links before assuming the 
 
 #### "List ID was inaccessible during last gravity run" warning won't go away
 
-If you previously added a bare domain name as a list URL (see "Invalid protocol" above) and later fixed it by moving the domain to **Domains** > **Allowlist**, FTL can keep showing the old warning for that list ID until it restarts, even though a fresh `sudo pihole -g` runs clean.
+If you previously added a bare domain name as a list URL (see [Invalid protocol](#gravity-shows-invalid-protocol-errors-for-domain-names) above) and later fixed it by moving the domain to **Domains** > **Allowlist**, FTL can keep showing the old warning for that list ID until it restarts, even though a fresh `sudo pihole -g` runs clean.
 
 **Check**: run `sudo pihole -g` and confirm no errors appear for the current run.
 If it's clean, the warning is stale.


### PR DESCRIPTION
## Summary
- Root-caused a 2026-07-23 disk near-miss: Netdata was installed on the **nightly** apt channel, which ships a new build daily via `apt-daily-upgrade.timer` with the superseded package left behind in `/var/cache/apt/archives` (~100-150MB/day, no ceiling). Fixed live (stable channel + `apt-get clean` + a weekly `APT::Periodic::AutocleanInterval` autoclean config) and documented the fix and root cause.
- Applied and documented three additional low-risk hardening items verified live on the Pi: disabled unused SSH `X11Forwarding`, installed and verified `unattended-upgrades` (security-only origins on by default, auto-reboot confirmed off), and installed the separate `unbound-anchor` package the existing unbound root-hint troubleshooting step was missing.
- Regenerated `pihole.toml.example` against the live v6.7 config (`EDNS0ECS`, `listeningMode`, `ntp.sync.active`, `macNames`, `debug.performance`, restored CSP `form-action 'self'`, removed a stale `pid` field) so the reference copy in the docs matches reality again.
- Added two new troubleshooting entries: a disk-fills-up-and-it's-not-the-FTL-database case pointing at the Netdata/apt-cache root cause, and a fix for a stale "List ID was inaccessible" gravity warning that survives a clean `pihole -g` run until FTL restarts.
- Investigated further hardening (removing preinstalled desktop apps, removing `rpcbind`/`nfs-common`, SSH key-based auth) and deliberately did **not** act on it — the first two turned out to cascade into removing Raspberry Pi OS Desktop metapackages on this image, and the payoff didn't justify the resulting nonstandard system state; SSH key auth was judged not worth the added setup complexity for this guide's audience. Nothing about these is in the docs.

## Test plan
- [x] Every command added or changed in these docs was run successfully against the live Pi-hole (Core v6.4.3 / Web v6.6 / FTL v6.7) during this session before being written up
- [x] `pihole.toml.example` diffed against a normalized live-config dump; remaining differences are cosmetic only (formatting, redacted password placeholder)
- [x] `markdownlint-cli2` run against the four changed files: 3 findings, all pre-existing (confirmed via `git diff HEAD`), none introduced by this change
- [x] Reviewed the diff for shell code blocks with multiple stacked commands or a missing `sudo`; fixed 5 instances so every block is copy-paste safe as a single line

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CnqaDPRKyP6MZRKK1yBxCH