### PR TITLE
Document HaGeZi legacy list format deprecation

### DIFF
--- a/src/content/docs/pi-hole/troubleshooting.mdx
+++ b/src/content/docs/pi-hole/troubleshooting.mdx
@@ -441,6 +441,44 @@ If it's clean, the warning is stale.
 
 **Fix**: `sudo systemctl restart pihole-FTL` clears it.
 
+#### How to update deprecated HaGeZi URL lists to adblock format
+
+**Symptom**: Sites, apps, or your smart TV start showing ads and trackers again after months of clean browsing, with no changes on your end.
+`sudo pihole -g` shows one of your HaGeZi lists 404ing or downloading 0 domains.
+
+**Cause**: HaGeZi [deprecated the legacy `domains` and `hosts` format lists](https://github.com/hagezi/dns-blocklists/discussions/10545) on August 1, 2026.
+Those formats enumerate every subdomain explicitly, which made files huge and unable to block unknown subdomains.
+Only software using an outdated matching engine - Pi-hole with FTL older than v5.22, plus old versions of Blocky, Diversion, pfBlockerNG, and similar - ever needed them.
+If you heard about this change and are looking to update your HaGeZi lists to the new format, that's exactly what the fix below does.
+
+**Fix**: Switch the list to the `adblock` format, which HaGeZi is not deprecating and which Pi-hole v6 (FTL well past v5.22) supports natively.
+
+The lists in [Recommended blocklists](/docs/pi-hole/block-allow-lists/#recommended-blocklists) already use the `adblock` path, so if you copied your list URLs from there, no change is needed.
+
+If you added a HaGeZi list some other way and it's now broken, replace it with a new one:
+
+<Steps>
+
+1. In the Pi-hole web interface, go to **Lists**.
+1. Use the search box to find the list you want to replace and select the trash icon to remove it.
+1. In the **Add a new subscribed list** section, add the replacement list's URL in the **Address**.
+
+   See [Recommended blocklists](/docs/pi-hole/block-allow-lists/#recommended-blocklists) for the current HaGeZi URLs.
+
+1. Select **Add blocklist**.
+
+1. After you add all the lists, update the Pi-hole's list settings (what it calls "Gravity") in **Tools** > **Update Gravity** to apply them, or use the CLI:
+
+   ```shell title="From the Pi"
+   sudo pihole -g
+   ```
+
+   Gravity also runs automatically on a weekly schedule.
+
+</Steps>
+
+After 2026-08-01, the old `/domains/` and `/hosts/` URLs only work from HaGeZi's separate [legacy repo](https://github.com/hagezi/dns-blocklists-legacy), which still gets daily updates but isn't the primary distribution.
+
 ## Tailscale
 
 ### DNS queries aren't showing in the Pi-hole query log


### PR DESCRIPTION
## Summary
- Adds a troubleshooting entry for HaGeZi's August 2026 deprecation of the legacy `domains`/`hosts` blocklist formats
- Framed around the symptom users actually hit (ads/trackers reappearing), not the underlying cause, with a delete-and-re-add fix using the current Pi-hole v6 Lists UI

## Test plan
- [x] Confirm the new section renders correctly in the built site
- [x] Verify the `#recommended-blocklists` anchor link resolves