### PR TITLE
Document Monday.com allowlist fix (HaGeZi Pro blocks ei.monday.com)

### DIFF
--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -957,7 +957,7 @@ If a service breaks again after you've already allowlisted it, check the query l
 [Verified: Tested, July 2026]
 
 ```shell title="From the Pi"
-pihole allowlist geolocation.onetrust.com registerdisney.go.com global.edge.bamgrid.com disney.demdex.net
+sudo pihole allowlist geolocation.onetrust.com registerdisney.go.com global.edge.bamgrid.com disney.demdex.net
 ```
 
 | Domain                     | Why it's needed |
@@ -986,7 +986,7 @@ That only helps if you watch in a browser.
 For the native apps, the ad-free tier is the only reliable option.
 
 ```shell title="From the Pi"
-pihole allowlist geolocation.onetrust.com
+sudo pihole allowlist geolocation.onetrust.com
 ```
 
 | Domain                     | Why it's needed |
@@ -1041,7 +1041,7 @@ Blocking them can break the entire app ecosystem, not just one service.
 If the TV reports no internet connection or the Apps screen won't open, one of these is blocked.
 
 ```shell title="From the Pi"
-pihole allowlist cdn.samsungcloudsolution.com lcprd1.samsungcloudsolution.net time.samsungcloudsolution.net time.samsungcloudsolution.com osb.samsungqbe.com
+sudo pihole allowlist cdn.samsungcloudsolution.com lcprd1.samsungcloudsolution.net time.samsungcloudsolution.net time.samsungcloudsolution.com osb.samsungqbe.com
 ```
 
 | Domain                            | Why it's needed |
@@ -1067,7 +1067,7 @@ Fire TV uses a captive-portal check to decide whether it has internet.
 If that check is blocked, the device shows a network error or hangs on the home screen.
 
 ```shell title="From the Pi"
-pihole allowlist fireoscaptiveportal.com firetvcaptiveportal.com dp-discovery-na-ext.amazon.com
+sudo pihole allowlist fireoscaptiveportal.com firetvcaptiveportal.com dp-discovery-na-ext.amazon.com
 ```
 
 | Domain                           | Why it's needed |
@@ -1109,6 +1109,26 @@ If that happens, use the query log method above rather than guessing, because th
 
 Compiled from the [ozankiratli streaming whitelist gist](https://gist.github.com/ozankiratli/801ba17705e7f2a904d2e443af5a64f8) and [cybernews' Roku ad blocking guide](https://cybernews.com/best-ad-blockers/how-to-block-ads-on-roku-tv/). *(Accessed 28 July 2026.)*
 Not tested on my own hardware.
+
+#### Monday.com
+
+[Verified: Tested, August 2026]
+
+HaGeZi Pro blocks two real monday.com domains: `ei.monday.com` and `track-visit.monday.com`.
+Both are tracking endpoints, but `ei.monday.com` also carries in-app signaling the app depends on, such as marking an export job as finished.
+Blocking it can make features like PDF export hang instead of failing with a clear error.
+
+```shell title="From the Pi"
+sudo pihole allowlist ei.monday.com
+```
+
+| Domain             | Why it's needed |
+|--------------------|------------------|
+| `ei.monday.com`    | Event-ingestion endpoint the app also uses for in-app signaling (for example, marking an export job complete). Blocking it can hang features like PDF export rather than erroring cleanly |
+
+`track-visit.monday.com` is also blocked by HaGeZi Pro but never appeared in the query log during normal use.
+It's likely marketing/referral tracking rather than something the app itself needs, so it wasn't allowlisted here.
+If you hit a different broken feature, check the query log before assuming you need it too.
 
 ## Control Blocking Per Device with Groups
 
@@ -1938,7 +1958,6 @@ If you want to change the database size:
 Source: https://edwardangert.com/docs/pi-hole/troubleshooting/
 
 
-
 ## Enable/Disable Debug Logging
 
 The Pi-hole debug tool turns on verbose logging flags when run.
@@ -2252,7 +2271,7 @@ It can't process bare domain names as list entries.
 Then re-add those domains via CLI or under **Domains** > **Allowlist**:
 
 ```shell title="From the Pi"
-pihole allowlist geolocation.onetrust.com registerdisney.go.com
+sudo pihole allowlist geolocation.onetrust.com registerdisney.go.com
 ```
 
 Gravity still runs successfully - blocked domain counts are unaffected.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -13,7 +13,7 @@ The full text of the guide is at https://edwardangert.com/llms-full.txt.
 - [Pi-hole v6 Setup Guide](https://edwardangert.com/docs/pi-hole/): Overview of the full build: HaGeZi blocklists, streaming allowlists, optional unbound recursive DNS, Tailscale remote access, and Netdata monitoring.
 - [Set Up Raspberry Pi OS](https://edwardangert.com/docs/pi-hole/install-configure/): Flash the SD card, harden with UFW and Fail2Ban, and set a static IP.
 - [Install Pi-hole v6](https://edwardangert.com/docs/pi-hole/pihole-install/): Install with Cloudflare DNS, log in to the web interface, and optionally add unbound recursive DNS and Netdata monitoring.
-- [Add Blocklists and Allowlists](https://edwardangert.com/docs/pi-hole/block-allow-lists/): Choose a HaGeZi tier, fix streaming services broken by Pi-hole, and control blocking per device with groups. Includes per-service allowlist domains for Disney+, Hulu, Paramount+, Samsung Smart TVs, Amazon Fire TV, and Roku, with the reason each domain is needed.
+- [Add Blocklists and Allowlists](https://edwardangert.com/docs/pi-hole/block-allow-lists/): Choose a HaGeZi tier, fix streaming services broken by Pi-hole, and control blocking per device with groups. Includes per-service allowlist domains for Disney+, Hulu, Paramount+, Samsung Smart TVs, Amazon Fire TV, Roku, and Monday.com, with the reason each domain is needed.
 
 Load-bearing conclusions from that page, which answer the questions it is most often cited for:
 

--- a/src/content/docs/pi-hole/block-allow-lists.mdx
+++ b/src/content/docs/pi-hole/block-allow-lists.mdx
@@ -249,7 +249,7 @@ If a service breaks again after you've already allowlisted it, check the query l
 <Verified date="2026-07" method="tested" />
 
 ```shell title="From the Pi"
-pihole allowlist geolocation.onetrust.com registerdisney.go.com global.edge.bamgrid.com disney.demdex.net
+sudo pihole allowlist geolocation.onetrust.com registerdisney.go.com global.edge.bamgrid.com disney.demdex.net
 ```
 
 | Domain                     | Why it's needed |
@@ -278,7 +278,7 @@ That only helps if you watch in a browser.
 For the native apps, the ad-free tier is the only reliable option.
 
 ```shell title="From the Pi"
-pihole allowlist geolocation.onetrust.com
+sudo pihole allowlist geolocation.onetrust.com
 ```
 
 | Domain                     | Why it's needed |
@@ -333,7 +333,7 @@ Blocking them can break the entire app ecosystem, not just one service.
 If the TV reports no internet connection or the Apps screen won't open, one of these is blocked.
 
 ```shell title="From the Pi"
-pihole allowlist cdn.samsungcloudsolution.com lcprd1.samsungcloudsolution.net time.samsungcloudsolution.net time.samsungcloudsolution.com osb.samsungqbe.com
+sudo pihole allowlist cdn.samsungcloudsolution.com lcprd1.samsungcloudsolution.net time.samsungcloudsolution.net time.samsungcloudsolution.com osb.samsungqbe.com
 ```
 
 | Domain                            | Why it's needed |
@@ -359,7 +359,7 @@ Fire TV uses a captive-portal check to decide whether it has internet.
 If that check is blocked, the device shows a network error or hangs on the home screen.
 
 ```shell title="From the Pi"
-pihole allowlist fireoscaptiveportal.com firetvcaptiveportal.com dp-discovery-na-ext.amazon.com
+sudo pihole allowlist fireoscaptiveportal.com firetvcaptiveportal.com dp-discovery-na-ext.amazon.com
 ```
 
 | Domain                           | Why it's needed |
@@ -401,6 +401,26 @@ If that happens, use the query log method above rather than guessing, because th
 
 Compiled from the [ozankiratli streaming whitelist gist](https://gist.github.com/ozankiratli/801ba17705e7f2a904d2e443af5a64f8) and [cybernews' Roku ad blocking guide](https://cybernews.com/best-ad-blockers/how-to-block-ads-on-roku-tv/). *(Accessed 28 July 2026.)*
 Not tested on my own hardware.
+
+#### Monday.com
+
+<Verified date="2026-08" method="tested" />
+
+HaGeZi Pro blocks two real monday.com domains: `ei.monday.com` and `track-visit.monday.com`.
+Both are tracking endpoints, but `ei.monday.com` also carries in-app signaling the app depends on, such as marking an export job as finished.
+Blocking it can make features like PDF export hang instead of failing with a clear error.
+
+```shell title="From the Pi"
+sudo pihole allowlist ei.monday.com
+```
+
+| Domain             | Why it's needed |
+|--------------------|------------------|
+| `ei.monday.com`    | Event-ingestion endpoint the app also uses for in-app signaling (for example, marking an export job complete). Blocking it can hang features like PDF export rather than erroring cleanly |
+
+`track-visit.monday.com` is also blocked by HaGeZi Pro but never appeared in the query log during normal use.
+It's likely marketing/referral tracking rather than something the app itself needs, so it wasn't allowlisted here.
+If you hit a different broken feature, check the query log before assuming you need it too.
 
 ## Control Blocking Per Device with Groups
 

--- a/src/content/docs/pi-hole/troubleshooting.mdx
+++ b/src/content/docs/pi-hole/troubleshooting.mdx
@@ -333,7 +333,7 @@ It can't process bare domain names as list entries.
 Then re-add those domains via CLI or under **Domains** > **Allowlist**:
 
 ```shell title="From the Pi"
-pihole allowlist geolocation.onetrust.com registerdisney.go.com
+sudo pihole allowlist geolocation.onetrust.com registerdisney.go.com
 ```
 
 Gravity still runs successfully - blocked domain counts are unaffected.


### PR DESCRIPTION
## Summary
- HaGeZi Pro blocks `ei.monday.com`, which broke monday.com features like PDF export for a client on the network. Diagnosed via the Pi-hole FTL query database and fixed with `sudo pihole allow ei.monday.com`.
- Adds a Monday.com entry to the block-allow-lists guide's per-service pattern (Verified badge, command, domain table), noting `track-visit.monday.com` is also blocked by HaGeZi Pro but wasn't needed here.
- Fixes every `pihole allowlist` example across `block-allow-lists.mdx` and `troubleshooting.mdx` to include `sudo`, which the command actually requires (pre-existing bug, not introduced by this change).
- Regenerates `llms-full.txt` for the two affected sections so it stays in sync with the source docs.

## Test plan
- [ ] Skim the new Monday.com section renders correctly (Verified badge, table, code block)
- [ ] Spot-check a couple of the `sudo` fixes in the rendered page