### PR TITLE
Remove fixed table column widths

### DIFF
--- a/src/styles/tables.css
+++ b/src/styles/tables.css
@@ -34,36 +34,29 @@ td {
 }
 
 /*
- * Column sizing for the three-column resume and portfolio tables.
+ * No column widths here on purpose.
  *
- * Scoped to tables that actually have three columns. Unscoped, the widths
- * total 100% across the first, second, and last columns, so a four-column
- * table leaves its third column with nothing and wraps that cell one
- * character per line. Two-column tables size better from their content than
- * from a 35/50 split.
+ * This file used to set 35% on the first column, 50% on the second, and 15%
+ * on the last. Those were picked for the resume tables (role, long
+ * description, date) and applied to every table on the site, so any table
+ * with a different shape got the wrong proportions:
  *
- * Browsers without `:has()` support fall back to automatic sizing, which is
- * the safe direction.
+ *   - a four-column table left its third column with 0% and wrapped that
+ *     cell one character per line, since 35 + 50 + 15 already totals 100
+ *   - a "domain / action / why" table gave 50% to cells reading "Block" and
+ *     squeezed the explanation into 15%
+ *
+ * Any fixed percentage is a guess about content the stylesheet cannot see.
+ * `table-layout: auto` on the rule above sizes each column from what is
+ * actually in it, which is what these overrides were fighting.
+ *
+ * If one table ever genuinely needs a hint, scope it to that table rather
+ * than reintroducing a site-wide rule.
  */
-table:has(th:nth-child(3)):not(:has(th:nth-child(4))) th:last-child,
-table:has(th:nth-child(3)):not(:has(th:nth-child(4))) td:last-child {
-  width: 15%;
-}
-
-table:has(th:nth-child(3)):not(:has(th:nth-child(4))) th:first-child,
-table:has(th:nth-child(3)):not(:has(th:nth-child(4))) td:first-child {
-  width: 35%;
-}
-
-table:has(th:nth-child(3)):not(:has(th:nth-child(4))) th:nth-child(2),
-table:has(th:nth-child(3)):not(:has(th:nth-child(4))) td:nth-child(2) {
-  width: 50%;
-}
 
 /*
- * Keep file paths and commands in a cell from forcing a column wide enough to
- * squeeze its neighbours. They still wrap on the separators rather than
- * mid-word.
+ * Long paths, domains, and commands still need to wrap, or a single cell can
+ * force its column wide enough to squeeze the others.
  */
 td code {
   overflow-wrap: anywhere;

--- a/src/styles/tables.css
+++ b/src/styles/tables.css
@@ -33,20 +33,40 @@ td {
   overflow-wrap: break-word;
 }
 
-/* Smart column sizing for typical resume tables */
-th:last-child,
-td:last-child {
+/*
+ * Column sizing for the three-column resume and portfolio tables.
+ *
+ * Scoped to tables that actually have three columns. Unscoped, the widths
+ * total 100% across the first, second, and last columns, so a four-column
+ * table leaves its third column with nothing and wraps that cell one
+ * character per line. Two-column tables size better from their content than
+ * from a 35/50 split.
+ *
+ * Browsers without `:has()` support fall back to automatic sizing, which is
+ * the safe direction.
+ */
+table:has(th:nth-child(3)):not(:has(th:nth-child(4))) th:last-child,
+table:has(th:nth-child(3)):not(:has(th:nth-child(4))) td:last-child {
   width: 15%;
 }
 
-th:first-child,
-td:first-child {
+table:has(th:nth-child(3)):not(:has(th:nth-child(4))) th:first-child,
+table:has(th:nth-child(3)):not(:has(th:nth-child(4))) td:first-child {
   width: 35%;
 }
 
-th:nth-child(2),
-td:nth-child(2) {
+table:has(th:nth-child(3)):not(:has(th:nth-child(4))) th:nth-child(2),
+table:has(th:nth-child(3)):not(:has(th:nth-child(4))) td:nth-child(2) {
   width: 50%;
+}
+
+/*
+ * Keep file paths and commands in a cell from forcing a column wide enough to
+ * squeeze its neighbours. They still wrap on the separators rather than
+ * mid-word.
+ */
+td code {
+  overflow-wrap: anywhere;
 }
 
 /* Remove border from last row */


### PR DESCRIPTION
## What

`src/styles/tables.css` set fixed column widths on every table on the site:

```css
td:first-child  { width: 35%; }
td:nth-child(2) { width: 50%; }
td:last-child   { width: 15%; }
```

They were picked for one table's content and applied to all of them. This removes them.

## The two failure modes

**Four-column tables lost a column entirely.** 35 + 50 + 15 already totals 100%, and on a four-column table those rules land on columns 1, 2, and 4. The third gets nothing and wraps one character per line:

```
| File                       | Mode | Holds  | Needs access? |
|                            |      | Blockl | No, already   |
| /etc/pihole/gravity.db     | 0664 | ists,  | world-        |
|                            |      | group  | readable      |
|                            |      | s      |               |
```

**Three-column tables got proportions meant for different content.** In a "domain / action / why" table, 50% goes to cells reading `Block` and `Allow`, while the column carrying the actual explanation is squeezed into 15% and wraps a word per line.

Even the resume tables the widths were named for are not the shape they assume. `Role | Organization | Years` is three short columns, and giving Organization half the table helps nobody.

## The fix

Delete the widths. `table-layout: auto` was already set on the table rule and sizes each column from its content; these overrides were fighting it.

Any fixed percentage is a guess about content the stylesheet cannot see. Three column counts are in use across the site (12 two-column, 7 three-column, 5 four-column), with no shared shape between them.

Also keeps a wrap rule so a long path or domain in a cell cannot force its column wide enough to squeeze the others:

```css
td code { overflow-wrap: anywhere; }
```

A comment in the file records why there are no widths, with both failure modes, so this does not get reintroduced.

## Notes

- CSS only, no content or config changes.
- Independent of #56 and safe to merge first.
- The first commit here scoped the widths to three-column tables. It fixed the four-column case but kept the underlying problem, so the second commit removes them outright. Squash on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
