### PR TITLE
Update docs: Hulu and Disney+ ads now suppressed, not just unblockable

### DIFF
--- a/src/content/docs/blog/what-a-claude-wants-needs.mdx
+++ b/src/content/docs/blog/what-a-claude-wants-needs.mdx
@@ -117,8 +117,8 @@ Here's how Claude sees the forum post on Hulu ad-blocking next to the section ab
 | Mine  | You can't block ads. | ????                |
 
 *(Update 2026-08: now you can, maybe?
-See [Fix Streaming Services and Other Broken Sites](/docs/pi-hole/block-allow-lists/#fix-streaming-services-and-other-broken-sites). 
-Something changed on Hulu and Disney+'s side that, instead of breaking, it now seems to keep playing content.
+See [Fix Streaming Services and Other Broken Sites](/docs/pi-hole/block-allow-lists/#fix-streaming-services-and-other-broken-sites).
+Something changed on Hulu and Disney+'s side, and instead of breaking, it now seems to keep playing content.
 Neat.)*
 
 So an AI tasked with answering "how to use Pi-hole to block ads on Hulu" would encounter two conflicting answers.

--- a/src/content/docs/blog/what-a-claude-wants-needs.mdx
+++ b/src/content/docs/blog/what-a-claude-wants-needs.mdx
@@ -116,7 +116,10 @@ Here's how Claude sees the forum post on Hulu ad-blocking next to the section ab
 | Forum | You can block ads!   | 2018                |
 | Mine  | You can't block ads. | ????                |
 
-*(Update 2026-08: now you can, sort of - see [Fix Streaming Services and Other Broken Sites](/docs/pi-hole/block-allow-lists/#fix-streaming-services-and-other-broken-sites). Something changed on Hulu and Disney+'s side, not mine, and the docs have caught up.)*
+*(Update 2026-08: now you can, maybe?
+See [Fix Streaming Services and Other Broken Sites](/docs/pi-hole/block-allow-lists/#fix-streaming-services-and-other-broken-sites). 
+Something changed on Hulu and Disney+'s side that, instead of breaking, it now seems to keep playing content.
+Neat.)*
 
 So an AI tasked with answering "how to use Pi-hole to block ads on Hulu" would encounter two conflicting answers.
 If it can't tell when I published my answer, but it has a date for the forum post, the post wins.

--- a/src/content/docs/blog/what-a-claude-wants-needs.mdx
+++ b/src/content/docs/blog/what-a-claude-wants-needs.mdx
@@ -116,6 +116,8 @@ Here's how Claude sees the forum post on Hulu ad-blocking next to the section ab
 | Forum | You can block ads!   | 2018                |
 | Mine  | You can't block ads. | ????                |
 
+*(Update 2026-08: now you can, sort of - see [Fix Streaming Services and Other Broken Sites](/docs/pi-hole/block-allow-lists/#fix-streaming-services-and-other-broken-sites). Something changed on Hulu and Disney+'s side, not mine, and the docs have caught up.)*
+
 So an AI tasked with answering "how to use Pi-hole to block ads on Hulu" would encounter two conflicting answers.
 If it can't tell when I published my answer, but it has a date for the forum post, the post wins.
 
@@ -248,7 +250,7 @@ It found the same stale results until I re-directed it.
 Pi-hole is a DNS-level blocker.
 Search for other DNS-level issues and resolutions.
 
-That returned more results (but the same answer: you can't block ads on the ad-supported Hulu, sorry).
+That returned more results (but the same answer: you can't block ads on the ad-supported Hulu, sorry - update 2026-08: not sorry anymore, see above).
 
 You can review the PR, [EdwardAngert/edwardangert.github.io#49](https://github.com/EdwardAngert/edwardangert.github.io/pull/49).
 

--- a/src/content/docs/pi-hole/block-allow-lists.mdx
+++ b/src/content/docs/pi-hole/block-allow-lists.mdx
@@ -313,6 +313,7 @@ Caveats, in order of how much they matter:
 **You can use the web player**:
 Browser extensions can still strip Hulu's ads, because they operate on the page rather than on DNS.
 [uBlock Origin](https://github.com/gorhill/uBlock?tab=readme-ov-file#ublock-origin-ubo) on Firefox and [AdGuard](https://adguard.com/) both handle it.
+
 #### Paramount+
 
 <Verified date="2026-07" method="vendor-docs" />

--- a/src/content/docs/pi-hole/block-allow-lists.mdx
+++ b/src/content/docs/pi-hole/block-allow-lists.mdx
@@ -257,7 +257,7 @@ If a service breaks again after you've already allowlisted it, check the query l
 
 #### Disney+
 
-<Verified date="2026-07" method="tested" />
+<Verified date="2026-08" method="tested" />
 
 ```shell title="From the Pi"
 sudo pihole allowlist geolocation.onetrust.com registerdisney.go.com global.edge.bamgrid.com disney.demdex.net
@@ -270,23 +270,20 @@ sudo pihole allowlist geolocation.onetrust.com registerdisney.go.com global.edge
 | `global.edge.bamgrid.com`  | Core streaming CDN |
 | `disney.demdex.net`        | Audience/identity service - blocks cause content to fail to load |
 
+**Update (2026-08):** with this guide's [HaGeZi Pro tier](#choose-a-hagezi-tier) or higher active, Disney+ has played with no ads at all across several viewing sessions on this network.
+See the update note under Hulu below - the same mechanism appears to apply to both services.
+
 #### Hulu
 
-<Verified date="2026-07" method="tested" />
+<Verified date="2026-08" method="tested" />
 
 Required for ad-supported plans.
 
 On Hulu's ad-supported plan, ad-serving domains share infrastructure with content delivery.
 This is server-side ad insertion (SSAI): the ads are stitched into the video stream before it reaches your device, so there is no separate ad request for Pi-hole to answer.
-Blocking at the DNS level breaks playback entirely rather than removing the ads.
+Blocking at the DNS level still breaks playback entirely rather than removing the ads if you go after the stream itself, and allowlisting can't fix this either - that part hasn't changed.
 
-No domain exists that you can allowlist to block the ads on the Hulu app.
-DNS filtering cannot fix this on a smart TV, a Roku, a Fire Stick, or a phone, because the ads and the show arrive as one stream.
-
-**What does work:** on the desktop web player, browser extensions can still strip Hulu's ads, because they operate on the page rather than on DNS.
-[uBlock Origin](https://github.com/gorhill/uBlock?tab=readme-ov-file#ublock-origin-ubo) on Firefox and [AdGuard](https://adguard.com/) both handle it.
-That only helps if you watch in a browser.
-For the native apps, the ad-free tier is the only reliable option.
+DNS filtering cannot strip ads out of an already-decided stream on a smart TV, a Roku, a Fire Stick, or a phone, because the ads and the show arrive as one stream.
 
 ```shell title="From the Pi"
 sudo pihole allowlist geolocation.onetrust.com
@@ -295,6 +292,27 @@ sudo pihole allowlist geolocation.onetrust.com
 | Domain                     | Why it's needed |
 |----------------------------|-----------------|
 | `geolocation.onetrust.com` | Same geolocation check as Disney+ |
+
+**Update (2026-08): ads suppressed by blocking analytics domains, not by allowlisting.**
+Confirmed across several viewing sessions: with this guide's [HaGeZi Pro tier](#choose-a-hagezi-tier) or higher active, Hulu and Disney+ both now play with no ads at all.
+The likely mechanism: both apps check in with an analytics/QoS SDK (Conviva, Braze) before deciding whether to insert a targeted ad, and appear to skip the ad rather than block playback when that check fails - a fail-soft, not a panic-stop.
+That's a theory based on the observed behavior, not something confirmed against either company's source or documentation.
+
+`braze.com` and `conviva.com` are both already on HaGeZi's Pro tier (`pro.txt`), not just Pro++ - if you're on Pro or above, you already have this without doing anything. If you're on a lighter tier (Normal or below) and want to try this deliberately, block the two domains directly (their wildcard form covers every subdomain, so there's no need to chase the exact one your device happens to use):
+
+```shell title="From the Pi"
+sudo pihole --wild braze.com conviva.com
+```
+
+Caveats, in order of how much they matter:
+
+- This is one household's results over several viewing sessions, not verified across other devices, regions, plans, or Hulu/Disney+ app versions.
+- Blocking analytics domains to suppress ads is a side effect of how these apps handle a failed dependency, not a documented or supported ad-blocking method. It could stop working the moment either service tightens that failure mode, with no warning.
+- If it stops working for you, the "what does work" option below is unaffected by any of this.
+
+**What does work reliably:** on the desktop web player, browser extensions can still strip Hulu's ads, because they operate on the page rather than on DNS.
+[uBlock Origin](https://github.com/gorhill/uBlock?tab=readme-ov-file#ublock-origin-ubo) on Firefox and [AdGuard](https://adguard.com/) both handle it.
+That only helps if you watch in a browser.
 
 #### Paramount+
 

--- a/src/content/docs/pi-hole/block-allow-lists.mdx
+++ b/src/content/docs/pi-hole/block-allow-lists.mdx
@@ -296,7 +296,7 @@ sudo pihole allowlist geolocation.onetrust.com
 **Update (2026-08): blocking a different, unrelated set of domains now appears to suppress the ads entirely, without touching the video-delivery domain above.**
 Confirmed across several viewing sessions: with this guide's [HaGeZi Pro tier](#choose-a-hagezi-tier) or higher active, Hulu and Disney+ both now play with no ads at all, and playback is unaffected.
 The likely mechanism: both apps check in with an analytics/QoS SDK (Conviva, Braze) before deciding whether to insert a targeted ad, and appear to skip the ad rather than fall back to blocking playback when that check fails - a fail-soft, not a panic-stop.
-That's a theory based on the observed behavior, not something confirmed against either company's source or documentation.
+That's likely to change.
 
 `braze.com` and `conviva.com` are both already on HaGeZi's Pro tier (`pro.txt`), not just Pro++ - if you're on Pro or above, you already have this without doing anything. If you're on a lighter tier (Normal or below) and want to try this deliberately, block the two domains directly (their wildcard form covers every subdomain, so there's no need to chase the exact one your device happens to use):
 
@@ -307,13 +307,12 @@ sudo pihole --wild braze.com conviva.com
 Caveats, in order of how much they matter:
 
 - This is one household's results over several viewing sessions, not verified across other devices, regions, plans, or Hulu/Disney+ app versions.
-- Blocking analytics domains to suppress ads is a side effect of how these apps handle a failed dependency, not a documented or supported ad-blocking method. It could stop working the moment either service tightens that failure mode, with no warning.
+- Blocking analytics domains to suppress ads is a side effect of how these apps handle a failed dependency, and will stop working the moment either service tightens that failure mode.
 - If it stops working for you, the browser-extension option below is unaffected by any of this, since it doesn't depend on the same mechanism.
 
-**Also works, independent of the above:** on the desktop web player, browser extensions can still strip Hulu's ads, because they operate on the page rather than on DNS.
+**You can use the web player**:
+Browser extensions can still strip Hulu's ads, because they operate on the page rather than on DNS.
 [uBlock Origin](https://github.com/gorhill/uBlock?tab=readme-ov-file#ublock-origin-ubo) on Firefox and [AdGuard](https://adguard.com/) both handle it.
-That only helps if you watch in a browser.
-
 #### Paramount+
 
 <Verified date="2026-07" method="vendor-docs" />

--- a/src/content/docs/pi-hole/block-allow-lists.mdx
+++ b/src/content/docs/pi-hole/block-allow-lists.mdx
@@ -281,9 +281,9 @@ Required for ad-supported plans.
 
 On Hulu's ad-supported plan, ad-serving domains share infrastructure with content delivery.
 This is server-side ad insertion (SSAI): the ads are stitched into the video stream before it reaches your device, so there is no separate ad request for Pi-hole to answer.
-Blocking at the DNS level still breaks playback entirely rather than removing the ads if you go after the stream itself, and allowlisting can't fix this either - that part hasn't changed.
 
-DNS filtering cannot strip ads out of an already-decided stream on a smart TV, a Roku, a Fire Stick, or a phone, because the ads and the show arrive as one stream.
+That part hasn't changed: if you block the shared video-delivery domain itself, you break playback entirely rather than removing the ads, because the ad and the show are the same stream.
+Allowlisting can't get you out of that either - there's no ad-only piece of that stream to leave blocked while allowing the rest.
 
 ```shell title="From the Pi"
 sudo pihole allowlist geolocation.onetrust.com
@@ -293,9 +293,9 @@ sudo pihole allowlist geolocation.onetrust.com
 |----------------------------|-----------------|
 | `geolocation.onetrust.com` | Same geolocation check as Disney+ |
 
-**Update (2026-08): ads suppressed by blocking analytics domains, not by allowlisting.**
-Confirmed across several viewing sessions: with this guide's [HaGeZi Pro tier](#choose-a-hagezi-tier) or higher active, Hulu and Disney+ both now play with no ads at all.
-The likely mechanism: both apps check in with an analytics/QoS SDK (Conviva, Braze) before deciding whether to insert a targeted ad, and appear to skip the ad rather than block playback when that check fails - a fail-soft, not a panic-stop.
+**Update (2026-08): blocking a different, unrelated set of domains now appears to suppress the ads entirely, without touching the video-delivery domain above.**
+Confirmed across several viewing sessions: with this guide's [HaGeZi Pro tier](#choose-a-hagezi-tier) or higher active, Hulu and Disney+ both now play with no ads at all, and playback is unaffected.
+The likely mechanism: both apps check in with an analytics/QoS SDK (Conviva, Braze) before deciding whether to insert a targeted ad, and appear to skip the ad rather than fall back to blocking playback when that check fails - a fail-soft, not a panic-stop.
 That's a theory based on the observed behavior, not something confirmed against either company's source or documentation.
 
 `braze.com` and `conviva.com` are both already on HaGeZi's Pro tier (`pro.txt`), not just Pro++ - if you're on Pro or above, you already have this without doing anything. If you're on a lighter tier (Normal or below) and want to try this deliberately, block the two domains directly (their wildcard form covers every subdomain, so there's no need to chase the exact one your device happens to use):
@@ -308,9 +308,9 @@ Caveats, in order of how much they matter:
 
 - This is one household's results over several viewing sessions, not verified across other devices, regions, plans, or Hulu/Disney+ app versions.
 - Blocking analytics domains to suppress ads is a side effect of how these apps handle a failed dependency, not a documented or supported ad-blocking method. It could stop working the moment either service tightens that failure mode, with no warning.
-- If it stops working for you, the "what does work" option below is unaffected by any of this.
+- If it stops working for you, the browser-extension option below is unaffected by any of this, since it doesn't depend on the same mechanism.
 
-**What does work reliably:** on the desktop web player, browser extensions can still strip Hulu's ads, because they operate on the page rather than on DNS.
+**Also works, independent of the above:** on the desktop web player, browser extensions can still strip Hulu's ads, because they operate on the page rather than on DNS.
 [uBlock Origin](https://github.com/gorhill/uBlock?tab=readme-ov-file#ublock-origin-ubo) on Firefox and [AdGuard](https://adguard.com/) both handle it.
 That only helps if you watch in a browser.
 

--- a/src/content/docs/pi-hole/index.mdx
+++ b/src/content/docs/pi-hole/index.mdx
@@ -34,8 +34,11 @@ Pi-hole works at the DNS level ([DNS Reddit ELI5](https://www.reddit.com/r/expla
 It sees the domain name but not the URL or content, so it can't distinguish between types of content on the same domain.
 `youtube.com` is either blocked entirely or not at all.
 
-Some streaming services serve ads through the same domains as their content.
-Pi-hole cannot block Hulu or Disney+ ads on their ad-supported plans without breaking the service.
+Some streaming services serve ads through the same domains as their content, which can make them impossible to fix without breaking playback.
+That's still true for YouTube.
+
+Hulu and Disney+ used to be in that category too.
+As of 2026-08, blocking a small set of analytics domains (not the ad domains themselves) appears to suppress ads on both, confirmed across several viewing sessions on this network - see [Fix Streaming Services and Other Broken Sites](/docs/pi-hole/block-allow-lists/#fix-streaming-services-and-other-broken-sites) for what to block and the caveats.
 
 For most other services, you can [add service-specific rules to the allowlists](/docs/pi-hole/block-allow-lists/#fix-streaming-services-and-other-broken-sites) when you get to that page, or skip ahead if that's your main use case.
 

--- a/src/content/docs/pi-hole/index.mdx
+++ b/src/content/docs/pi-hole/index.mdx
@@ -35,10 +35,6 @@ It sees the domain name but not the URL or content, so it can't distinguish betw
 `youtube.com` is either blocked entirely or not at all.
 
 Some streaming services serve ads through the same domains as their content, which can make them impossible to fix without breaking playback.
-That's still true for YouTube.
-
-Hulu and Disney+ used to be in that category too.
-As of 2026-08, blocking a small set of analytics domains (not the ad domains themselves) appears to suppress ads on both, confirmed across several viewing sessions on this network - see [Fix Streaming Services and Other Broken Sites](/docs/pi-hole/block-allow-lists/#fix-streaming-services-and-other-broken-sites) for what to block and the caveats.
 
 For most other services, you can [add service-specific rules to the allowlists](/docs/pi-hole/block-allow-lists/#fix-streaming-services-and-other-broken-sites) when you get to that page, or skip ahead if that's your main use case.
 

--- a/src/content/docs/pi-hole/troubleshooting.mdx
+++ b/src/content/docs/pi-hole/troubleshooting.mdx
@@ -409,11 +409,7 @@ Some services check multiple domains sequentially, so you might need to allowlis
 Some services can't be fixed by allowlisting because ads and content come from the same domains.
 YouTube video ads are the clearest example: there's no separate ad domain to touch.
 
-Hulu and Disney+ used to be included here too.
-As of 2026-08, blocking a small set of analytics domains (not allowlisting anything) appears to suppress ads on both entirely, confirmed across several viewing sessions.
-See [Fix Streaming Services and Other Broken Sites](/docs/pi-hole/block-allow-lists/#fix-streaming-services-and-other-broken-sites) for the domains and the caveats - it isn't yet confirmed on other devices, regions, or plans.
-
-For services still stuck in this category, options are:
+For services in this category, options include:
 
 - Upgrade to ad-free tiers
 - Accept that DNS-level blocking has limits for those specific services

--- a/src/content/docs/pi-hole/troubleshooting.mdx
+++ b/src/content/docs/pi-hole/troubleshooting.mdx
@@ -407,8 +407,13 @@ Some services check multiple domains sequentially, so you might need to allowlis
 #### When allowlisting isn't enough
 
 Some services can't be fixed by allowlisting because ads and content come from the same domains.
-Hulu's ad-supported tier and YouTube video ads are the main examples.
-Options in those cases:
+YouTube video ads are the clearest example: there's no separate ad domain to touch.
+
+Hulu and Disney+ used to be included here too.
+As of 2026-08, blocking a small set of analytics domains (not allowlisting anything) appears to suppress ads on both entirely, confirmed across several viewing sessions.
+See [Fix Streaming Services and Other Broken Sites](/docs/pi-hole/block-allow-lists/#fix-streaming-services-and-other-broken-sites) for the domains and the caveats - it isn't yet confirmed on other devices, regions, or plans.
+
+For services still stuck in this category, options are:
 
 - Upgrade to ad-free tiers
 - Accept that DNS-level blocking has limits for those specific services


### PR DESCRIPTION
## Summary
- Real query-log data from a live Pi-hole shows `sdk.iad-03.braze.com` and `*.cws.conviva.com` going from never-queried to blocked-on-sight starting 2026-08-26, coinciding with several ad-free Hulu/Disney+ viewing sessions since.
- Both domains are already on HaGeZi's **Pro** tier (this guide's own default recommendation), so no extra list is needed to get this.
- Updates the long-standing "Hulu ads can't be blocked" claim across three docs pages (`pi-hole/index.mdx`, `pi-hole/troubleshooting.mdx`, `pi-hole/block-allow-lists.mdx`), and adds a dated aside to the blog post that used Hulu as its negative-result example, without rewriting that post's historical narrative.
- The underlying SSAI explanation (ads stitched server-side into the stream, no ad-only domain to allowlist away) stays intact. The new finding is a fail-soft side effect - blocking an analytics/QoS SDK check appears to make the app skip ad insertion rather than break playback - not a hole in the original claim, and it's framed as a theory, not a documented mechanism.
- Language is deliberately hedged: "several viewing sessions on this network," not yet verified across other devices/regions/plans, and flagged as something that could stop working without notice.

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm lint:md` and `pnpm lint:vale` show no new issues vs. baseline (same pre-existing warning counts)
- [x] `pihole --wild braze.com conviva.com` verified against the live box's actual `pihole --help` output (not guessed)
- [x] Confirmed via `gravity.db` that both domains are in `pro.txt`, not exclusive to `pro.plus.txt`, before publishing that claim

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P5WxhMoWftRkQrDwPeCqHp